### PR TITLE
build: finish warnings-as-errors paved-road slice

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <LvlupTreatWarningsAsErrors>true</LvlupTreatWarningsAsErrors>
     <!-- MinVer: recognize v-prefixed tags like v1.0.0 -->
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -69,6 +69,7 @@
          so the host can start in TypeLoadMode.Dynamic. -->
     <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.12.0" />
     <PackageVersion Include="Marten" Version="9.9.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <!-- 4.14.0 lifts transitive SSH.NET to the CVE-2026-48798-patched 2026.0.0 release. -->
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Implements the remaining code-owned build-standard item from #147 and advances the #153 roadmap.\n\n- sets LvlupTreatWarningsAsErrors explicitly at the repository level\n- updates Testcontainers.PostgreSql 4.12.0 to 4.14.0, lifting transitive SSH.NET to the CVE-2026-48798-patched 2026.0.0 release\n\nLocal evidence:\n- Release solution build: 0 warnings, 0 errors\n- NuGet vulnerable scan including transitives: empty\n- all ordinary test assemblies passed; the Docker-backed generator behavioral assembly is delegated to CI after the local host did not complete it\n\nRefs #147, #133, #153.