### PR TITLE
ci: temporary @main parity baseline for #133

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     # movable, so the SHA is recorded here to make that visible; the workflows
     # themselves SHA-pin their internal composite actions, so the action graph
     # under this ref is fixed.
-    uses: lvlup-sw/.github/.github/workflows/build-and-test.yml@v1
+    uses: lvlup-sw/.github/.github/workflows/build-and-test.yml@main
     with:
       solution-path: 'src/strategos.slnx'
       test-project-patterns: |
@@ -150,7 +150,7 @@ jobs:
     needs: build-test
     if: github.event_name == 'pull_request'
     # v1 -> c10269573359bc91ff59fe5e9cb8090bbc6cb87a at pin time.
-    uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@v1
+    uses: lvlup-sw/.github/.github/workflows/coverage-gate.yml@main
     permissions:
       pull-requests: write
     with:
@@ -164,7 +164,7 @@ jobs:
     needs: build-test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     # v1 -> c10269573359bc91ff59fe5e9cb8090bbc6cb87a at pin time.
-    uses: lvlup-sw/.github/.github/workflows/update-baseline.yml@v1
+    uses: lvlup-sw/.github/.github/workflows/update-baseline.yml@main
 
   quality-gates:
     # T-023 / DR-7, DR-10, DR-11 grep gates. Pure shell — no .NET needed,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <LvlupTreatWarningsAsErrors>true</LvlupTreatWarningsAsErrors>
     <!-- MinVer: recognize v-prefixed tags like v1.0.0 -->
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -69,6 +69,7 @@
          so the host can start in TypeLoadMode.Dynamic. -->
     <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.12.0" />
     <PackageVersion Include="Marten" Version="9.9.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <!-- 4.14.0 lifts transitive SSH.NET to the CVE-2026-48798-patched 2026.0.0 release. -->
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Throwaway draft PR for the #133 consumer parity runbook. It contains the same code as #198 but runs the three Strategos CI reusable workflows at the pre-bump @main ref. Compare the coverage-gate verdict and bot comment against #198; this PR will be closed without merge after evidence is captured.\n\nRefs #133, #153.