### PR TITLE
Require authenticated principals for ontology actions

### DIFF
--- a/src/Strategos.Ontology.MCP.Hosting.Tests/ClaimsActionPrincipalResolverTests.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/ClaimsActionPrincipalResolverTests.cs
@@ -1,0 +1,51 @@
+using System.Security.Claims;
+
+using Strategos.Ontology.MCP.Hosting;
+
+namespace Strategos.Ontology.MCP.Hosting.Tests;
+
+public sealed class ClaimsActionPrincipalResolverTests
+{
+    [Test]
+    public async Task Resolve_AuthenticatedCallerWithRequiredClaims_BindsPrincipal()
+    {
+        var caller = CreateCaller(
+            new Claim(ActionPrincipalClaimTypes.PrincipalType, "User"),
+            new Claim(ClaimTypes.NameIdentifier, "user-1"));
+
+        var principal = ClaimsActionPrincipalResolver.Instance.Resolve(caller);
+
+        await Assert.That(principal).IsNotNull();
+        await Assert.That(principal!.PrincipalType).IsEqualTo("User");
+        await Assert.That(principal.PrincipalId).IsEqualTo("user-1");
+    }
+
+    [Test]
+    public async Task Resolve_SubjectClaim_BindsPrincipalId()
+    {
+        var caller = CreateCaller(
+            new Claim(ActionPrincipalClaimTypes.PrincipalType, "Agent"),
+            new Claim("sub", "agent-1"));
+
+        var principal = ClaimsActionPrincipalResolver.Instance.Resolve(caller);
+
+        await Assert.That(principal).IsNotNull();
+        await Assert.That(principal!.PrincipalId).IsEqualTo("agent-1");
+    }
+
+    [Test]
+    public async Task Resolve_UnauthenticatedOrIncompleteCaller_RefusesBinding()
+    {
+        var unauthenticated = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ActionPrincipalClaimTypes.PrincipalType, "User"), new Claim("sub", "user-1")]));
+        var missingType = CreateCaller(new Claim("sub", "user-1"));
+        var missingId = CreateCaller(new Claim(ActionPrincipalClaimTypes.PrincipalType, "User"));
+
+        await Assert.That(ClaimsActionPrincipalResolver.Instance.Resolve(unauthenticated)).IsNull();
+        await Assert.That(ClaimsActionPrincipalResolver.Instance.Resolve(missingType)).IsNull();
+        await Assert.That(ClaimsActionPrincipalResolver.Instance.Resolve(missingId)).IsNull();
+    }
+
+    private static ClaimsPrincipal CreateCaller(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "test"));
+}

--- a/src/Strategos.Ontology.MCP.Hosting.Tests/ClaimsActionPrincipalResolverTests.cs
+++ b/src/Strategos.Ontology.MCP.Hosting.Tests/ClaimsActionPrincipalResolverTests.cs
@@ -4,8 +4,14 @@ using Strategos.Ontology.MCP.Hosting;
 
 namespace Strategos.Ontology.MCP.Hosting.Tests;
 
+/// <summary>
+/// Verifies fail-closed claims binding for ontology action principals.
+/// </summary>
 public sealed class ClaimsActionPrincipalResolverTests
 {
+    /// <summary>
+    /// Verifies that the required claims bind an authenticated caller.
+    /// </summary>
     [Test]
     public async Task Resolve_AuthenticatedCallerWithRequiredClaims_BindsPrincipal()
     {
@@ -20,6 +26,9 @@ public sealed class ClaimsActionPrincipalResolverTests
         await Assert.That(principal.PrincipalId).IsEqualTo("user-1");
     }
 
+    /// <summary>
+    /// Verifies that the standard subject claim can supply the principal ID.
+    /// </summary>
     [Test]
     public async Task Resolve_SubjectClaim_BindsPrincipalId()
     {
@@ -33,6 +42,9 @@ public sealed class ClaimsActionPrincipalResolverTests
         await Assert.That(principal!.PrincipalId).IsEqualTo("agent-1");
     }
 
+    /// <summary>
+    /// Verifies that unauthenticated or incomplete callers are refused.
+    /// </summary>
     [Test]
     public async Task Resolve_UnauthenticatedOrIncompleteCaller_RefusesBinding()
     {
@@ -46,6 +58,26 @@ public sealed class ClaimsActionPrincipalResolverTests
         await Assert.That(ClaimsActionPrincipalResolver.Instance.Resolve(missingId)).IsNull();
     }
 
-    private static ClaimsPrincipal CreateCaller(params Claim[] claims) =>
-        new(new ClaimsIdentity(claims, authenticationType: "test"));
+    /// <summary>
+    /// Verifies that claims from another unauthenticated identity cannot be
+    /// borrowed by the authenticated primary identity.
+    /// </summary>
+    [Test]
+    public async Task Resolve_ClaimsOnlyOnSecondaryUnauthenticatedIdentity_RefusesBinding()
+    {
+        var authenticated = new ClaimsIdentity(authenticationType: "test");
+        var unauthenticated = new ClaimsIdentity(
+        [
+            new Claim(ActionPrincipalClaimTypes.PrincipalType, "User"),
+            new Claim("sub", "user-1"),
+        ]);
+        var caller = new ClaimsPrincipal([authenticated, unauthenticated]);
+
+        await Assert.That(ClaimsActionPrincipalResolver.Instance.Resolve(caller)).IsNull();
+    }
+
+    private static ClaimsPrincipal CreateCaller(params Claim[] claims)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "test"));
+    }
 }

--- a/src/Strategos.Ontology.MCP.Hosting/ActionPrincipalClaimTypes.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/ActionPrincipalClaimTypes.cs
@@ -1,0 +1,12 @@
+namespace Strategos.Ontology.MCP.Hosting;
+
+/// <summary>
+/// Claim names consumed by the default ontology action-principal resolver.
+/// </summary>
+public static class ActionPrincipalClaimTypes
+{
+    /// <summary>
+    /// Claim whose value names the ontology descriptor type of the caller.
+    /// </summary>
+    public const string PrincipalType = "strategos:principal_type";
+}

--- a/src/Strategos.Ontology.MCP.Hosting/ClaimsActionPrincipalResolver.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/ClaimsActionPrincipalResolver.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+
+using Strategos.Ontology.Actions;
+
+namespace Strategos.Ontology.MCP.Hosting;
+
+/// <summary>
+/// Resolves MCP callers from standard subject identifiers plus the Strategos
+/// ontology principal-type claim.
+/// </summary>
+public sealed class ClaimsActionPrincipalResolver : IActionPrincipalResolver
+{
+    /// <summary>
+    /// Shared stateless resolver used when a host does not register a custom resolver.
+    /// </summary>
+    public static ClaimsActionPrincipalResolver Instance { get; } = new();
+
+    /// <inheritdoc />
+    public ActionPrincipal? Resolve(ClaimsPrincipal caller)
+    {
+        ArgumentNullException.ThrowIfNull(caller);
+
+        if (caller.Identity?.IsAuthenticated is not true)
+        {
+            return null;
+        }
+
+        var principalType = caller.FindFirst(ActionPrincipalClaimTypes.PrincipalType)?.Value;
+        var principalId = caller.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? caller.FindFirst("sub")?.Value;
+
+        return string.IsNullOrWhiteSpace(principalType) || string.IsNullOrWhiteSpace(principalId)
+            ? null
+            : new ActionPrincipal(principalType, principalId);
+    }
+}

--- a/src/Strategos.Ontology.MCP.Hosting/ClaimsActionPrincipalResolver.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/ClaimsActionPrincipalResolver.cs
@@ -20,14 +20,14 @@ public sealed class ClaimsActionPrincipalResolver : IActionPrincipalResolver
     {
         ArgumentNullException.ThrowIfNull(caller);
 
-        if (caller.Identity?.IsAuthenticated is not true)
+        if (caller.Identity is not ClaimsIdentity identity || !identity.IsAuthenticated)
         {
             return null;
         }
 
-        var principalType = caller.FindFirst(ActionPrincipalClaimTypes.PrincipalType)?.Value;
-        var principalId = caller.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? caller.FindFirst("sub")?.Value;
+        var principalType = identity.FindFirst(ActionPrincipalClaimTypes.PrincipalType)?.Value;
+        var principalId = identity.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? identity.FindFirst("sub")?.Value;
 
         return string.IsNullOrWhiteSpace(principalType) || string.IsNullOrWhiteSpace(principalId)
             ? null

--- a/src/Strategos.Ontology.MCP.Hosting/IActionPrincipalResolver.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/IActionPrincipalResolver.cs
@@ -1,0 +1,19 @@
+using System.Security.Claims;
+
+using Strategos.Ontology.Actions;
+
+namespace Strategos.Ontology.MCP.Hosting;
+
+/// <summary>
+/// Resolves an ontology action principal from an authenticated MCP caller.
+/// </summary>
+public interface IActionPrincipalResolver
+{
+    /// <summary>
+    /// Resolves <paramref name="caller"/> to an ontology principal, or returns
+    /// <c>null</c> when the caller cannot be bound safely.
+    /// </summary>
+    /// <param name="caller">Authenticated caller supplied by the MCP transport.</param>
+    /// <returns>The bound ontology principal, or <c>null</c> to refuse dispatch.</returns>
+    ActionPrincipal? Resolve(ClaimsPrincipal caller);
+}

--- a/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
@@ -202,8 +202,14 @@ public static class OntologyServerToolFactory
                     "ontology_action requires an IActionDispatcher to be registered in the host's service provider.");
 
             var tool = new OntologyActionTool(graph, dispatcher, ResolveObjectSetProvider(context));
+            var principalResolver = context.Services?.GetService<IActionPrincipalResolver>()
+                ?? ClaimsActionPrincipalResolver.Instance;
+            var principal = context.User is null
+                ? null
+                : principalResolver.Resolve(context.User);
 
             return await tool.ExecuteAsync(
+                principal,
                 objectType,
                 action,
                 request,

--- a/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
+++ b/src/Strategos.Ontology.MCP.Hosting/OntologyServerToolFactory.cs
@@ -204,7 +204,7 @@ public static class OntologyServerToolFactory
             var tool = new OntologyActionTool(graph, dispatcher, ResolveObjectSetProvider(context));
             var principalResolver = context.Services?.GetService<IActionPrincipalResolver>()
                 ?? ClaimsActionPrincipalResolver.Instance;
-            var principal = context.User is null
+            var principal = context.User?.Identity?.IsAuthenticated is not true
                 ? null
                 : principalResolver.Resolve(context.User);
 

--- a/src/Strategos.Ontology.MCP.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Ontology.MCP.Hosting/PublicAPI.Unshipped.txt
@@ -1,7 +1,15 @@
 #nullable enable
+const Strategos.Ontology.MCP.Hosting.ActionPrincipalClaimTypes.PrincipalType = "strategos:principal_type" -> string!
 Microsoft.Extensions.DependencyInjection.OntologyMcpServerBuilderExtensions
 static Microsoft.Extensions.DependencyInjection.OntologyMcpServerBuilderExtensions.AddOntologyTools(this Microsoft.Extensions.DependencyInjection.IMcpServerBuilder! builder) -> Microsoft.Extensions.DependencyInjection.IMcpServerBuilder!
 static Microsoft.Extensions.DependencyInjection.OntologyMcpServerBuilderExtensions.AddOntologyTools(this Microsoft.Extensions.DependencyInjection.IMcpServerBuilder! builder, Strategos.Ontology.OntologyGraph! graph) -> Microsoft.Extensions.DependencyInjection.IMcpServerBuilder!
+static Strategos.Ontology.MCP.Hosting.ClaimsActionPrincipalResolver.Instance.get -> Strategos.Ontology.MCP.Hosting.ClaimsActionPrincipalResolver!
 static Strategos.Ontology.MCP.Hosting.OntologyServerToolFactory.CreateAnswerComposer(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> Strategos.Ontology.MCP.OntologyAnswerComposer!
 static Strategos.Ontology.MCP.Hosting.OntologyServerToolFactory.CreateServerTools(Strategos.Ontology.OntologyGraph! graph) -> System.Collections.Generic.IEnumerable<ModelContextProtocol.Server.McpServerTool!>!
+Strategos.Ontology.MCP.Hosting.ActionPrincipalClaimTypes
+Strategos.Ontology.MCP.Hosting.ClaimsActionPrincipalResolver
+Strategos.Ontology.MCP.Hosting.ClaimsActionPrincipalResolver.ClaimsActionPrincipalResolver() -> void
+Strategos.Ontology.MCP.Hosting.ClaimsActionPrincipalResolver.Resolve(System.Security.Claims.ClaimsPrincipal! caller) -> Strategos.Ontology.Actions.ActionPrincipal?
+Strategos.Ontology.MCP.Hosting.IActionPrincipalResolver
+Strategos.Ontology.MCP.Hosting.IActionPrincipalResolver.Resolve(System.Security.Claims.ClaimsPrincipal! caller) -> Strategos.Ontology.Actions.ActionPrincipal?
 Strategos.Ontology.MCP.Hosting.OntologyServerToolFactory

--- a/src/Strategos.Ontology.MCP.Hosting/README.md
+++ b/src/Strategos.Ontology.MCP.Hosting/README.md
@@ -28,6 +28,14 @@ builder.Services
 
 `AddOntologyTools` discovers the four ontology tools (`ontology_explore`, `ontology_query`, `ontology_action`, `ontology_validate`) and registers them as **provider-bound** MCP server tools: each tool dispatches against the host's DI-resolved `IObjectSetProvider` (and, where applicable, `IActionDispatcher`, `IEventStreamProvider`, `IOntologyQuery`), resolved per call from the request's `IServiceProvider`. So `ontology_query` executes against the configured provider and returns real rows.
 
+`ontology_action` is fail-closed: it dispatches only when the MCP transport supplies an authenticated `ClaimsPrincipal` that can be bound to an ontology principal. The default resolver reads the principal ID from `ClaimTypes.NameIdentifier` (or `sub`) and requires an `ActionPrincipalClaimTypes.PrincipalType` claim whose value is the caller's ontology descriptor name. Register a custom `IActionPrincipalResolver` when the host uses different claims:
+
+```csharp
+builder.Services.AddSingleton<IActionPrincipalResolver, MyActionPrincipalResolver>();
+```
+
+Missing authentication, principal type, or principal ID returns a failed action result without invoking `IActionDispatcher`.
+
 It also registers `ontology_traverse` — an instance-anchored traversal tool that walks from a specific object instance across a reified association to a far endpoint, with edge-attribute filtering. Its inputs are closed-vocabulary (a `linkName` from the graph, an integer `depth` ≤ 3, a `direction` of `ToDestination`/`ToSource`); malformed arguments return `isError: true` (never a thrown protocol error), and a large subgraph returns a `resource_link` plus an opaque cursor. Use the `ontology_explore` `associations` scope to discover the reified associations and endpoints to traverse.
 
 The no-argument overload resolves the `OntologyGraph` from the service collection. Pass a graph explicitly when it is not registered there:

--- a/src/Strategos.Ontology.MCP.Tests/EndToEndDispatchValidationTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/EndToEndDispatchValidationTests.cs
@@ -217,10 +217,11 @@ public class EndToEndDispatchValidationTests
             NullLogger<ObservableActionDispatcher>.Instance);
 
         var context = new ActionContext(
-            Domain: "e2e-trading",
-            ObjectType: "E2EPosition",
-            ObjectId: "pos-1",
-            ActionName: "get_position")
+            principal: new ActionPrincipal("User", "user-1"),
+            domain: "e2e-trading",
+            objectType: "E2EPosition",
+            objectId: "pos-1",
+            actionName: "get_position")
         {
             ActionDescriptor = readOnlyDescriptor,
         };
@@ -256,10 +257,11 @@ public class EndToEndDispatchValidationTests
         // No known properties supplied — the RequiresLink("Position") precondition
         // is unsatisfied when the link is absent from knownProperties.
         var context = new ActionContext(
-            Domain: "e2e-trading",
-            ObjectType: "E2EOrder",
-            ObjectId: "ord-1",
-            ActionName: "submit_order")
+            principal: new ActionPrincipal("User", "user-1"),
+            domain: "e2e-trading",
+            objectType: "E2EOrder",
+            objectId: "ord-1",
+            actionName: "submit_order")
         {
             ActionDescriptor = mutatingDescriptor,
         };

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolMetaTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolMetaTests.cs
@@ -6,6 +6,8 @@ namespace Strategos.Ontology.MCP.Tests;
 
 public class OntologyActionToolMetaTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     [Test]
     public async Task Action_ResultCarriesMetaWithGraphVersion()
     {
@@ -21,6 +23,7 @@ public class OntologyActionToolMetaTests
 
         // Act — single-object dispatch
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: new { },
@@ -49,6 +52,7 @@ public class OntologyActionToolMetaTests
         var tool = new OntologyActionTool(graph, dispatcher, provider);
 
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: new { },
@@ -71,6 +75,7 @@ public class OntologyActionToolMetaTests
 
         // Unknown object type
         var r1 = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "DoesNotExist",
             action: "noop",
             request: new { },
@@ -80,6 +85,7 @@ public class OntologyActionToolMetaTests
 
         // Unknown action on a real type
         var r2 = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "no_such_action",
             request: new { },
@@ -102,6 +108,7 @@ public class OntologyActionToolMetaTests
         var tool = new OntologyActionTool(graph, dispatcher, provider);
 
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: new { },

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolResilienceTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolResilienceTests.cs
@@ -15,6 +15,8 @@ namespace Strategos.Ontology.MCP.Tests;
 /// </summary>
 public class OntologyActionToolResilienceTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     private OntologyGraph _graph = null!;
     private IActionDispatcher _actionDispatcher = null!;
     private IObjectSetProvider _objectSetProvider = null!;
@@ -36,6 +38,7 @@ public class OntologyActionToolResilienceTests
 
         // Act
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "NonExistentType",
             action: "some_action",
             request: new { },
@@ -55,6 +58,7 @@ public class OntologyActionToolResilienceTests
 
         // Act
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "nonexistent_action",
             request: new { },
@@ -87,6 +91,7 @@ public class OntologyActionToolResilienceTests
 
         // Act
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: new { },

--- a/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/OntologyActionToolTests.cs
@@ -7,6 +7,8 @@ namespace Strategos.Ontology.MCP.Tests;
 
 public class OntologyActionToolTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     private OntologyGraph _graph = null!;
     private IActionDispatcher _actionDispatcher = null!;
     private IObjectSetProvider _objectSetProvider = null!;
@@ -34,6 +36,7 @@ public class OntologyActionToolTests
 
         // Act
         var result = await _tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: request,
@@ -48,6 +51,7 @@ public class OntologyActionToolTests
         await _actionDispatcher.Received(1).DispatchAsync(
             Arg.Is<ActionContext>(ctx =>
                 ctx.Domain == "trading"
+                && ctx.Principal == Principal
                 && ctx.ObjectType == "TestPosition"
                 && ctx.ObjectId == "p1"
                 && ctx.ActionName == "execute_trade"),
@@ -77,6 +81,7 @@ public class OntologyActionToolTests
 
         // Act
         var result = await _tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: request,
@@ -118,6 +123,7 @@ public class OntologyActionToolTests
 
         // Act
         await _tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "execute_trade",
             request: request,
@@ -138,6 +144,7 @@ public class OntologyActionToolTests
     {
         // Act
         var result = await _tool.ExecuteAsync(
+            principal: Principal,
             objectType: "TestPosition",
             action: "nonexistent_action",
             request: new { },
@@ -155,6 +162,7 @@ public class OntologyActionToolTests
     {
         // Act
         var result = await _tool.ExecuteAsync(
+            principal: Principal,
             objectType: "NonExistentType",
             action: "some_action",
             request: new { },
@@ -193,6 +201,7 @@ public class OntologyActionToolTests
 
         // Act — batch dispatch (no objectId, so DispatchBatchAsync is reached)
         var result = await tool.ExecuteAsync(
+            principal: Principal,
             objectType: "trading_documents",
             action: "execute_trade",
             request: new { },
@@ -207,6 +216,24 @@ public class OntologyActionToolTests
         await Assert.That(root).IsNotNull();
         await Assert.That(root!.ObjectTypeName).IsEqualTo("trading_documents");
         await Assert.That(root.ObjectType).IsEqualTo(typeof(TestPosition));
+    }
+
+    [Test]
+    public async Task OntologyAction_MissingPrincipal_IsRefusedBeforeDispatch()
+    {
+        var result = await _tool.ExecuteAsync(
+            principal: null,
+            objectType: "TestPosition",
+            action: "execute_trade",
+            request: new { },
+            domain: "trading",
+            objectId: "p1");
+
+        await Assert.That(result.Results).HasCount().EqualTo(1);
+        await Assert.That(result.Results[0].IsSuccess).IsFalse();
+        await Assert.That(result.Results[0].Error).Contains("principal");
+        await _actionDispatcher.DidNotReceiveWithAnyArgs()
+            .DispatchAsync(default!, default!, default);
     }
 }
 

--- a/src/Strategos.Ontology.MCP.Tests/RelateActionGatingTests.cs
+++ b/src/Strategos.Ontology.MCP.Tests/RelateActionGatingTests.cs
@@ -16,6 +16,8 @@ namespace Strategos.Ontology.MCP.Tests;
 /// </summary>
 public sealed class RelateActionGatingTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     public sealed record Account(string Id, string Status = "open");
 
     public sealed record Holder(string Id);
@@ -71,8 +73,8 @@ public sealed class RelateActionGatingTests
         var tool = new OntologyActionTool(graph, dispatcher, provider);
 
         // Act — relate, then unrelate, both as ACTIONS on a single object.
-        await tool.ExecuteAsync("Account", "relate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
-        await tool.ExecuteAsync("Account", "unrelate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
+        await tool.ExecuteAsync(Principal, "Account", "relate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
+        await tool.ExecuteAsync(Principal, "Account", "unrelate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
 
         // Assert — BOTH went through the action dispatcher (the gate), never a direct
         // writer call.
@@ -102,7 +104,7 @@ public sealed class RelateActionGatingTests
 
         // Act
         var result = await tool.ExecuteAsync(
-            "Account", "relate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
+            Principal, "Account", "relate_holder", new RelateRequest("h1"), domain: "rel", objectId: "a1");
 
         // Assert — the relate was denied at the gate.
         await Assert.That(result.Results).HasCount().EqualTo(1);

--- a/src/Strategos.Ontology.MCP/OntologyActionTool.cs
+++ b/src/Strategos.Ontology.MCP/OntologyActionTool.cs
@@ -48,6 +48,7 @@ public sealed class OntologyActionTool
     /// Executes an action on a single object or a filtered set of objects.
     /// </summary>
     public async Task<ActionToolResult> ExecuteAsync(
+        ActionPrincipal? principal,
         string objectType,
         string action,
         object request,
@@ -58,6 +59,13 @@ public sealed class OntologyActionTool
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(objectType);
         ArgumentException.ThrowIfNullOrWhiteSpace(action);
+
+        if (principal is null)
+        {
+            return new ActionToolResult(
+                [new ActionResult(false, Error: "An authenticated action principal is required.")],
+                CurrentMeta());
+        }
 
         var resolvedDomain = domain ?? ResolveDomain(objectType);
 
@@ -91,15 +99,16 @@ public sealed class OntologyActionTool
 
         if (objectId is not null)
         {
-            return await DispatchSingleAsync(validDomain, objectType, objectId, action, request, ct)
+            return await DispatchSingleAsync(principal, validDomain, objectType, objectId, action, request, ct)
                 .ConfigureAwait(false);
         }
 
-        return await DispatchBatchAsync(validDomain, objectType, action, request, filter, ct)
+        return await DispatchBatchAsync(principal, validDomain, objectType, action, request, filter, ct)
             .ConfigureAwait(false);
     }
 
     private async Task<ActionToolResult> DispatchSingleAsync(
+        ActionPrincipal principal,
         string domain,
         string objectType,
         string objectId,
@@ -107,7 +116,7 @@ public sealed class OntologyActionTool
         object request,
         CancellationToken ct)
     {
-        var context = new ActionContext(domain, objectType, objectId, action);
+        var context = new ActionContext(principal, domain, objectType, objectId, action);
         var result = await _actionDispatcher.DispatchAsync(context, request, ct).ConfigureAwait(false);
         return new ActionToolResult([result], CurrentMeta());
     }
@@ -115,6 +124,7 @@ public sealed class OntologyActionTool
     private ResponseMeta CurrentMeta() => ResponseMeta.ForGraph(_graph);
 
     private async Task<ActionToolResult> DispatchBatchAsync(
+        ActionPrincipal principal,
         string domain,
         string objectType,
         string action,
@@ -140,7 +150,7 @@ public sealed class OntologyActionTool
         foreach (var item in queryResult.Items)
         {
             var itemId = item?.ToString() ?? string.Empty;
-            var context = new ActionContext(domain, objectType, itemId, action);
+            var context = new ActionContext(principal, domain, objectType, itemId, action);
             try
             {
                 var actionResult = await _actionDispatcher.DispatchAsync(context, request, ct).ConfigureAwait(false);

--- a/src/Strategos.Ontology.MCP/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Ontology.MCP/PublicAPI.Unshipped.txt
@@ -91,7 +91,7 @@ Strategos.Ontology.MCP.OntologyAbstainedRecord.NearestRecordsCount.get -> int
 Strategos.Ontology.MCP.OntologyAbstainedRecord.OntologyAbstainedRecord(int nearestRecordsCount) -> void
 Strategos.Ontology.MCP.OntologyAbstainedRecord.Type.get -> string!
 Strategos.Ontology.MCP.OntologyActionTool
-Strategos.Ontology.MCP.OntologyActionTool.ExecuteAsync(string! objectType, string! action, object! request, string? domain = null, string? objectId = null, string? filter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Strategos.Ontology.MCP.ActionToolResult!>!
+Strategos.Ontology.MCP.OntologyActionTool.ExecuteAsync(Strategos.Ontology.Actions.ActionPrincipal? principal, string! objectType, string! action, object! request, string? domain = null, string? objectId = null, string? filter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Strategos.Ontology.MCP.ActionToolResult!>!
 Strategos.Ontology.MCP.OntologyActionTool.OntologyActionTool(Strategos.Ontology.OntologyGraph! graph, Strategos.Ontology.Actions.IActionDispatcher! actionDispatcher, Strategos.Ontology.ObjectSets.IObjectSetProvider! objectSetProvider) -> void
 Strategos.Ontology.MCP.OntologyActionTool.OntologyActionTool(Strategos.Ontology.OntologyGraph! graph, Strategos.Ontology.Actions.IActionDispatcher! actionDispatcher, Strategos.Ontology.ObjectSets.IObjectSetProvider! objectSetProvider, Microsoft.Extensions.Logging.ILogger<Strategos.Ontology.MCP.OntologyActionTool!>! logger) -> void
 Strategos.Ontology.MCP.OntologyAnswerComposer

--- a/src/Strategos.Ontology.MCP/README.md
+++ b/src/Strategos.Ontology.MCP/README.md
@@ -39,6 +39,20 @@ Each action tool descriptor includes `ActionConstraintSummary` records with hard
 - **Constraint Summaries**: Hard/soft constraint counts embedded in tool descriptions for zero-shot agent reasoning
 - **Python Stubs**: `OntologyStubGenerator` produces `.pyi`-style type stubs for agent tooling
 
+Direct action-tool callers must bind the authenticated caller explicitly:
+
+```csharp
+var principal = new ActionPrincipal("User", "user-42");
+var result = await actionTool.ExecuteAsync(
+    principal,
+    objectType: "Order",
+    action: "submit",
+    request: request,
+    objectId: "order-7");
+```
+
+Passing no principal is refused before the dispatcher is called. The MCP hosting package resolves this value from the authenticated request automatically.
+
 ## License
 
 MIT

--- a/src/Strategos.Ontology.Tests/Actions/ActionDispatcherTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/ActionDispatcherTests.cs
@@ -4,17 +4,20 @@ namespace Strategos.Ontology.Tests.Actions;
 
 public class ActionDispatcherTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     [Test]
     public async Task ActionContext_Create_HasDomainObjectTypeAndAction()
     {
         // Arrange & Act
-        var context = new ActionContext("CRM", "Contact", "c-1", "SendEmail");
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "SendEmail");
 
         // Assert
         await Assert.That(context.Domain).IsEqualTo("CRM");
         await Assert.That(context.ObjectType).IsEqualTo("Contact");
         await Assert.That(context.ObjectId).IsEqualTo("c-1");
         await Assert.That(context.ActionName).IsEqualTo("SendEmail");
+        await Assert.That(context.Principal).IsSameReferenceAs(Principal);
     }
 
     [Test]
@@ -46,7 +49,7 @@ public class ActionDispatcherTests
     {
         // Arrange
         var dispatcher = Substitute.For<IActionDispatcher>();
-        var context = new ActionContext("CRM", "Contact", "c-1", "SendEmail");
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "SendEmail");
         var request = new { To = "test@example.com" };
         dispatcher.DispatchAsync(context, request, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new ActionResult(true, Result: "sent")));
@@ -62,7 +65,7 @@ public class ActionDispatcherTests
     public async Task ActionContext_Options_DefaultsToNull()
     {
         // Arrange & Act
-        var context = new ActionContext("CRM", "Contact", "c-1", "SendEmail");
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "SendEmail");
 
         // Assert
         await Assert.That(context.Options).IsNull();
@@ -73,11 +76,18 @@ public class ActionDispatcherTests
     {
         // Arrange & Act
         var options = new ActionDispatchOptions { EnforcePreconditions = true };
-        var context = new ActionContext("CRM", "Contact", "c-1", "SendEmail", options);
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "SendEmail", options);
 
         // Assert
         await Assert.That(context.Options).IsNotNull();
         await Assert.That(context.Options!.EnforcePreconditions).IsTrue();
+    }
+
+    [Test]
+    public async Task ActionContext_MissingPrincipal_Throws()
+    {
+        await Assert.That(() => new ActionContext(null!, "CRM", "Contact", "c-1", "SendEmail"))
+            .Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/src/Strategos.Ontology.Tests/Actions/ActionPrincipalTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/ActionPrincipalTests.cs
@@ -1,0 +1,42 @@
+using Strategos.Ontology.Actions;
+
+namespace Strategos.Ontology.Tests.Actions;
+
+public sealed class ActionPrincipalTests
+{
+    [Test]
+    public async Task Constructor_ValidTypeAndId_PreservesValues()
+    {
+        var principal = new ActionPrincipal("ServiceAccount", "svc-42");
+
+        await Assert.That(principal.PrincipalType).IsEqualTo("ServiceAccount");
+        await Assert.That(principal.PrincipalId).IsEqualTo("svc-42");
+    }
+
+    [Test]
+    [Arguments(null, "id")]
+    [Arguments("", "id")]
+    [Arguments(" ", "id")]
+    [Arguments("User", null)]
+    [Arguments("User", "")]
+    [Arguments("User", " ")]
+    public async Task Constructor_MissingTypeOrId_Throws(string? principalType, string? principalId)
+    {
+        await Assert.That(() => new ActionPrincipal(principalType!, principalId!))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ActionContext_RecordCloneCannotRemovePrincipal()
+    {
+        var context = new ActionContext(
+            new ActionPrincipal("User", "user-1"),
+            "Sales",
+            "Order",
+            "order-1",
+            "Approve");
+
+        await Assert.That(() => context with { Principal = null! })
+            .Throws<ArgumentNullException>();
+    }
+}

--- a/src/Strategos.Ontology.Tests/Actions/ActionPrincipalTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/ActionPrincipalTests.cs
@@ -2,8 +2,14 @@ using Strategos.Ontology.Actions;
 
 namespace Strategos.Ontology.Tests.Actions;
 
+/// <summary>
+/// Verifies the immutable ontology action-principal contract.
+/// </summary>
 public sealed class ActionPrincipalTests
 {
+    /// <summary>
+    /// Verifies that valid principal coordinates are preserved.
+    /// </summary>
     [Test]
     public async Task Constructor_ValidTypeAndId_PreservesValues()
     {
@@ -13,6 +19,9 @@ public sealed class ActionPrincipalTests
         await Assert.That(principal.PrincipalId).IsEqualTo("svc-42");
     }
 
+    /// <summary>
+    /// Verifies that neither principal coordinate may be blank.
+    /// </summary>
     [Test]
     [Arguments(null, "id")]
     [Arguments("", "id")]
@@ -26,6 +35,9 @@ public sealed class ActionPrincipalTests
             .Throws<ArgumentException>();
     }
 
+    /// <summary>
+    /// Verifies that record cloning cannot remove a context principal.
+    /// </summary>
     [Test]
     public async Task ActionContext_RecordCloneCannotRemovePrincipal()
     {

--- a/src/Strategos.Ontology.Tests/Actions/ConstraintReportingActionDispatcherTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/ConstraintReportingActionDispatcherTests.cs
@@ -10,7 +10,7 @@ public class ConstraintReportingActionDispatcherTests
     private static ActionContext MakeContext(
         string actionName,
         ActionDescriptor? descriptor = null) =>
-        new("CRM", "Order", "o-1", actionName)
+        new(new ActionPrincipal("User", "user-1"), "CRM", "Order", "o-1", actionName)
         {
             ActionDescriptor = descriptor,
         };

--- a/src/Strategos.Ontology.Tests/Actions/DispatchReadOnlyAsyncTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/DispatchReadOnlyAsyncTests.cs
@@ -5,6 +5,8 @@ namespace Strategos.Ontology.Tests.Actions;
 
 public class DispatchReadOnlyAsyncTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     private sealed class CapturingDispatcher : IActionDispatcher
     {
         private readonly ActionResult _result;
@@ -32,7 +34,7 @@ public class DispatchReadOnlyAsyncTests
         var expected = new ActionResult(true, Result: "ok");
         var dispatcher = new CapturingDispatcher(expected);
         var descriptor = new ActionDescriptor("GetPosition", "Read position") { IsReadOnly = true };
-        var context = new ActionContext("CRM", "Contact", "c-1", "GetPosition")
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "GetPosition")
         {
             ActionDescriptor = descriptor,
         };
@@ -52,7 +54,7 @@ public class DispatchReadOnlyAsyncTests
     {
         var dispatcher = new CapturingDispatcher(new ActionResult(true, Result: "should-not-see"));
         var descriptor = new ActionDescriptor("UpdatePosition", "Mutates position") { IsReadOnly = false };
-        var context = new ActionContext("CRM", "Contact", "c-1", "UpdatePosition")
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "UpdatePosition")
         {
             ActionDescriptor = descriptor,
         };
@@ -71,7 +73,7 @@ public class DispatchReadOnlyAsyncTests
     public async Task DispatchReadOnlyAsync_OnMissingDescriptor_ReturnsFailureWithoutCallingInner()
     {
         var dispatcher = new CapturingDispatcher(new ActionResult(true));
-        var context = new ActionContext("CRM", "Contact", "c-1", "Unknown");
+        var context = new ActionContext(Principal, "CRM", "Contact", "c-1", "Unknown");
         var request = new { Probe = 1 };
 
         var result = await ((IActionDispatcher)dispatcher).DispatchReadOnlyAsync(

--- a/src/Strategos.Ontology.Tests/Actions/ObservableActionDispatcherTests.cs
+++ b/src/Strategos.Ontology.Tests/Actions/ObservableActionDispatcherTests.cs
@@ -6,7 +6,7 @@ namespace Strategos.Ontology.Tests.Actions;
 public class ObservableActionDispatcherTests
 {
     private static ActionContext MakeContext() =>
-        new("CRM", "Order", "o-1", "Place");
+        new(new ActionPrincipal("User", "user-1"), "CRM", "Order", "o-1", "Place");
 
     [Test]
     public async Task Dispatch_AfterCompletion_InvokesAllRegisteredObservers()

--- a/src/Strategos.Ontology.Tests/Configuration/DispatcherDecoratorRegistrationTests.cs
+++ b/src/Strategos.Ontology.Tests/Configuration/DispatcherDecoratorRegistrationTests.cs
@@ -133,7 +133,12 @@ public class DispatcherDecoratorRegistrationTests
         var dispatcher = provider.GetRequiredService<IActionDispatcher>();
 
         // Resolves successfully and routes Dispatch through the inner stub.
-        var ctx = new ActionContext("test-domain", "TestPosition", "p-1", "Noop");
+        var ctx = new ActionContext(
+            new ActionPrincipal("User", "user-1"),
+            "test-domain",
+            "TestPosition",
+            "p-1",
+            "Noop");
         var result = await dispatcher.DispatchAsync(ctx, new { }, CancellationToken.None);
         await Assert.That(result.IsSuccess).IsTrue();
     }

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetActionEventTests.cs
@@ -6,6 +6,8 @@ namespace Strategos.Ontology.Tests.ObjectSets;
 
 public class ObjectSetActionEventTests
 {
+    private static readonly ActionPrincipal Principal = new("User", "user-1");
+
     private IObjectSetProvider _provider = null!;
     private IActionDispatcher _dispatcher = null!;
     private IEventStreamProvider _eventProvider = null!;
@@ -32,7 +34,7 @@ public class ObjectSetActionEventTests
         var set = new ObjectSet<string>(typeof(string).Name, _provider, _dispatcher, _eventProvider);
 
         // Act
-        var results = await set.ApplyAsync("DoSomething", new { Value = 1 });
+        var results = await set.ApplyAsync(Principal, "DoSomething", new { Value = 1 });
 
         // Assert
         await Assert.That(results).HasCount().EqualTo(1);
@@ -52,11 +54,11 @@ public class ObjectSetActionEventTests
         var request = new { To = "test@example.com" };
 
         // Act
-        await set.ApplyAsync("SendEmail", request);
+        await set.ApplyAsync(Principal, "SendEmail", request);
 
         // Assert
         await _dispatcher.Received(1).DispatchAsync(
-            Arg.Is<ActionContext>(c => c.ActionName == "SendEmail"),
+            Arg.Is<ActionContext>(c => c.ActionName == "SendEmail" && c.Principal == Principal),
             Arg.Is<object>(r => r == request),
             Arg.Any<CancellationToken>());
     }
@@ -125,7 +127,7 @@ public class ObjectSetActionEventTests
         var set = new ObjectSet<string>(descriptorName, _provider, _dispatcher, _eventProvider);
 
         // Act
-        await set.ApplyAsync("Archive", new { });
+        await set.ApplyAsync(Principal, "Archive", new { });
 
         // Assert — dispatcher receives the descriptor name, not "String"
         await _dispatcher.Received(1).DispatchAsync(

--- a/src/Strategos.Ontology/Actions/ActionContext.cs
+++ b/src/Strategos.Ontology/Actions/ActionContext.cs
@@ -3,20 +3,71 @@ using Strategos.Ontology.Descriptors;
 namespace Strategos.Ontology.Actions;
 
 /// <summary>
-/// Identifies the target of an ontology action invocation.
+/// Identifies the authenticated principal and target of an ontology action invocation.
 /// </summary>
-/// <param name="Domain">Domain that owns the target object type.</param>
-/// <param name="ObjectType">Simple object type name within the domain.</param>
-/// <param name="ObjectId">Identifier of the specific instance the action targets.</param>
-/// <param name="ActionName">Name of the action to invoke.</param>
-/// <param name="Options">Optional dispatch options that influence routing or hooks.</param>
-public sealed record ActionContext(
-    string Domain,
-    string ObjectType,
-    string ObjectId,
-    string ActionName,
-    ActionDispatchOptions? Options = null)
+public sealed record ActionContext
 {
+    private readonly ActionPrincipal principal = null!;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionContext"/> record.
+    /// </summary>
+    /// <param name="principal">Authenticated principal requesting the action.</param>
+    /// <param name="domain">Domain that owns the target object type.</param>
+    /// <param name="objectType">Simple object type name within the domain.</param>
+    /// <param name="objectId">Identifier of the specific instance the action targets.</param>
+    /// <param name="actionName">Name of the action to invoke.</param>
+    /// <param name="options">Optional dispatch options that influence routing or hooks.</param>
+    public ActionContext(
+        ActionPrincipal principal,
+        string domain,
+        string objectType,
+        string objectId,
+        string actionName,
+        ActionDispatchOptions? options = null)
+    {
+        Principal = principal;
+        Domain = domain;
+        ObjectType = objectType;
+        ObjectId = objectId;
+        ActionName = actionName;
+        Options = options;
+    }
+
+    /// <summary>
+    /// Gets the authenticated principal requesting the action.
+    /// </summary>
+    public ActionPrincipal Principal
+    {
+        get => principal;
+        init => principal = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets the domain that owns the target object type.
+    /// </summary>
+    public string Domain { get; init; }
+
+    /// <summary>
+    /// Gets the simple object type name within the domain.
+    /// </summary>
+    public string ObjectType { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the specific target instance.
+    /// </summary>
+    public string ObjectId { get; init; }
+
+    /// <summary>
+    /// Gets the name of the action to invoke.
+    /// </summary>
+    public string ActionName { get; init; }
+
+    /// <summary>
+    /// Gets dispatch options that influence routing or hooks.
+    /// </summary>
+    public ActionDispatchOptions? Options { get; init; }
+
     /// <summary>
     /// Optional resolved descriptor for the action being dispatched. When supplied,
     /// the dispatch path can apply descriptor-driven guards (such as the read-only

--- a/src/Strategos.Ontology/Actions/ActionContext.cs
+++ b/src/Strategos.Ontology/Actions/ActionContext.cs
@@ -10,7 +10,7 @@ public sealed record ActionContext
     private readonly ActionPrincipal principal = null!;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ActionContext"/> record.
+    /// Initializes a new instance of the <see cref="ActionContext"/> class.
     /// </summary>
     /// <param name="principal">Authenticated principal requesting the action.</param>
     /// <param name="domain">Domain that owns the target object type.</param>
@@ -26,6 +26,8 @@ public sealed record ActionContext
         string actionName,
         ActionDispatchOptions? options = null)
     {
+        ArgumentNullException.ThrowIfNull(principal);
+
         Principal = principal;
         Domain = domain;
         ObjectType = objectType;

--- a/src/Strategos.Ontology/Actions/ActionPrincipal.cs
+++ b/src/Strategos.Ontology/Actions/ActionPrincipal.cs
@@ -1,0 +1,38 @@
+namespace Strategos.Ontology.Actions;
+
+/// <summary>
+/// Identifies the authenticated principal requesting an ontology action.
+/// </summary>
+/// <remarks>
+/// <paramref name="principalType"/> is the ontology descriptor name for the
+/// principal (for example, <c>User</c> or <c>ServiceAccount</c>), and
+/// <paramref name="principalId"/> is the identifier of that descriptor instance.
+/// Both values are required so authorization checks can bind a caller to the
+/// ontology relation graph without assuming a CLR identity type.
+/// </remarks>
+public sealed record ActionPrincipal
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionPrincipal"/> record.
+    /// </summary>
+    /// <param name="principalType">Ontology descriptor name for the principal.</param>
+    /// <param name="principalId">Identifier of the principal instance.</param>
+    public ActionPrincipal(string principalType, string principalId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(principalType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(principalId);
+
+        PrincipalType = principalType;
+        PrincipalId = principalId;
+    }
+
+    /// <summary>
+    /// Gets the ontology descriptor name for the principal.
+    /// </summary>
+    public string PrincipalType { get; }
+
+    /// <summary>
+    /// Gets the identifier of the principal instance.
+    /// </summary>
+    public string PrincipalId { get; }
+}

--- a/src/Strategos.Ontology/Actions/ActionPrincipal.cs
+++ b/src/Strategos.Ontology/Actions/ActionPrincipal.cs
@@ -13,7 +13,7 @@ namespace Strategos.Ontology.Actions;
 public sealed record ActionPrincipal
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ActionPrincipal"/> record.
+    /// Initializes a new instance of the <see cref="ActionPrincipal"/> class.
     /// </summary>
     /// <param name="principalType">Ontology descriptor name for the principal.</param>
     /// <param name="principalId">Identifier of the principal instance.</param>

--- a/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
+++ b/src/Strategos.Ontology/ObjectSets/ObjectSet.cs
@@ -151,8 +151,19 @@ public sealed class ObjectSet<T> where T : class
     /// descriptor name carried on the expression's root, so a multi-registered CLR
     /// type reaches the registration the caller selected.
     /// </summary>
-    public async Task<IReadOnlyList<ActionResult>> ApplyAsync(string actionName, object request, CancellationToken ct = default)
+    /// <param name="principal">Authenticated principal requesting the action.</param>
+    /// <param name="actionName">Name of the action to apply.</param>
+    /// <param name="request">Action request payload.</param>
+    /// <param name="ct">Token used to cancel materialization or dispatch.</param>
+    /// <returns>One result for each materialized object.</returns>
+    public async Task<IReadOnlyList<ActionResult>> ApplyAsync(
+        ActionPrincipal principal,
+        string actionName,
+        object request,
+        CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(principal);
+
         var result = await _provider.ExecuteAsync<T>(Expression, ct).ConfigureAwait(false);
         var results = new List<ActionResult>(result.Items.Count);
         var descriptorName = Expression.RootObjectTypeName;
@@ -160,7 +171,7 @@ public sealed class ObjectSet<T> where T : class
         foreach (var item in result.Items)
         {
             var objectId = item?.ToString() ?? string.Empty;
-            var context = new ActionContext(descriptorName, descriptorName, objectId, actionName);
+            var context = new ActionContext(principal, descriptorName, descriptorName, objectId, actionName);
             var actionResult = await _actionDispatcher.DispatchAsync(context, request, ct).ConfigureAwait(false);
             results.Add(actionResult);
         }

--- a/src/Strategos.Ontology/PublicAPI.Unshipped.txt
+++ b/src/Strategos.Ontology/PublicAPI.Unshipped.txt
@@ -18,7 +18,7 @@ static Strategos.Ontology.Temporal.AssociationTemporalEvent.Assert(string! assoc
 static Strategos.Ontology.Temporal.AssociationTemporalEvent.Retract(string! associationId, System.DateTimeOffset systemTo, string? retractingAgent = null) -> Strategos.Ontology.Temporal.AssociationTemporalEvent!
 static Strategos.Ontology.Temporal.TemporalAssociationProjection.Replay(System.Collections.Generic.IEnumerable<Strategos.Ontology.Temporal.AssociationTemporalEvent!>! events) -> Strategos.Ontology.Temporal.TemporalAssociationProjection!
 Strategos.Ontology.Actions.ActionContext
-Strategos.Ontology.Actions.ActionContext.ActionContext(string! Domain, string! ObjectType, string! ObjectId, string! ActionName, Strategos.Ontology.Actions.ActionDispatchOptions? Options = null) -> void
+Strategos.Ontology.Actions.ActionContext.ActionContext(Strategos.Ontology.Actions.ActionPrincipal! principal, string! domain, string! objectType, string! objectId, string! actionName, Strategos.Ontology.Actions.ActionDispatchOptions? options = null) -> void
 Strategos.Ontology.Actions.ActionContext.ActionDescriptor.get -> Strategos.Ontology.Descriptors.ActionDescriptor?
 Strategos.Ontology.Actions.ActionContext.ActionDescriptor.init -> void
 Strategos.Ontology.Actions.ActionContext.ActionName.get -> string!
@@ -31,6 +31,12 @@ Strategos.Ontology.Actions.ActionContext.ObjectType.get -> string!
 Strategos.Ontology.Actions.ActionContext.ObjectType.init -> void
 Strategos.Ontology.Actions.ActionContext.Options.get -> Strategos.Ontology.Actions.ActionDispatchOptions?
 Strategos.Ontology.Actions.ActionContext.Options.init -> void
+Strategos.Ontology.Actions.ActionContext.Principal.get -> Strategos.Ontology.Actions.ActionPrincipal!
+Strategos.Ontology.Actions.ActionContext.Principal.init -> void
+Strategos.Ontology.Actions.ActionPrincipal
+Strategos.Ontology.Actions.ActionPrincipal.ActionPrincipal(string! principalType, string! principalId) -> void
+Strategos.Ontology.Actions.ActionPrincipal.PrincipalId.get -> string!
+Strategos.Ontology.Actions.ActionPrincipal.PrincipalType.get -> string!
 Strategos.Ontology.Actions.ActionDispatchOptions
 Strategos.Ontology.Actions.ActionDispatchOptions.EnforcePreconditions.get -> bool
 Strategos.Ontology.Actions.ActionDispatchOptions.EnforcePreconditions.init -> void
@@ -725,7 +731,7 @@ Strategos.Ontology.ObjectSets.IObjectSetWriter.UnrelateAsync(string! srcDescript
 Strategos.Ontology.ObjectSets.ISearchable
 Strategos.Ontology.ObjectSets.ISearchable.Embedding.get -> float[]!
 Strategos.Ontology.ObjectSets.ObjectSet<T>
-Strategos.Ontology.ObjectSets.ObjectSet<T>.ApplyAsync(string! actionName, object! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Strategos.Ontology.Actions.ActionResult!>!>!
+Strategos.Ontology.ObjectSets.ObjectSet<T>.ApplyAsync(Strategos.Ontology.Actions.ActionPrincipal! principal, string! actionName, object! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Strategos.Ontology.Actions.ActionResult!>!>!
 Strategos.Ontology.ObjectSets.ObjectSet<T>.EventsAsync(System.TimeSpan? since = null, System.Collections.Generic.IReadOnlyList<string!>? eventTypes = null) -> System.Collections.Generic.IAsyncEnumerable<Strategos.Ontology.Events.OntologyEvent!>!
 Strategos.Ontology.ObjectSets.ObjectSet<T>.ExecuteAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Strategos.Ontology.ObjectSets.ObjectSetResult<T!>!>!
 Strategos.Ontology.ObjectSets.ObjectSet<T>.Expression.get -> Strategos.Ontology.ObjectSets.ObjectSetExpression!


### PR DESCRIPTION
Closes #161

## Summary
- add a sealed ontology-owned `ActionPrincipal` with required principal type and ID
- require the principal in `ActionContext`, `ObjectSet.ApplyAsync`, and `OntologyActionTool.ExecuteAsync`
- bind authenticated MCP callers through a customizable `IActionPrincipalResolver`
- refuse missing or incomplete principals before invoking `IActionDispatcher`
- update public API baselines and package documentation

## Design
The principal lives in `Strategos.Ontology` rather than `Strategos.Identity.Abstractions`. This keeps the authorization contract expressed in ontology terms and avoids coupling the ontology kernel to a CLR identity implementation.

## Verification
- full Release solution build: 0 warnings, 0 errors
- Strategos.Ontology.Tests: 935 passed before the final focused regression; principal tests: 8 passed
- Strategos.Ontology.MCP.Tests: 214 passed
- Strategos.Ontology.MCP.Hosting.Tests: 27 passed
- `git diff --check`
- project design-invariant checks for runtime isolation, source-generation boundaries, sealed descriptors, public API baselines, and polyglot naming