### PR TITLE
ci: make the symbols push idempotent and keep rc releases pre-release

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -547,7 +547,13 @@ jobs:
           args: --latest --strip header
 
       - name: Create GitHub Release
+        # publish.yml updates this same release later with the packed artifacts.
+        # Keep the pre-release flags in step with it: a hyphenated tag
+        # (v3.0.0-rc.1) must never be published as a stable "Latest" release
+        # in the window before publish.yml's release step runs.
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.changelog.outputs.content }}
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}

--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -229,29 +229,19 @@ jobs:
           user: ${{ vars.NUGET_USER }}
 
       - name: Push to NuGet
+        # One push per nupkg, and no separate symbols step: `dotnet nuget push`
+        # sends the paired .snupkg from the same directory in the same call. A
+        # second PUT of that .snupkg while nuget.org is still validating the
+        # first is a 409 that fails the job after the package is already live
+        # and skips the GitHub Release step (contracts-v0.12.0, run 34430841560).
+        # A duplicate *package* push must stay a hard failure here, so nothing
+        # in this file asks NuGet to skip duplicates (CodegenGuardTests).
         run: |
           for package in ./packages/*.nupkg; do
             echo "Pushing $package..."
             dotnet nuget push "$package" \
               --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
               --source https://api.nuget.org/v3/index.json
-          done
-
-      - name: Push symbols
-        # `dotnet nuget push <pkg>.nupkg` already pushes the paired .snupkg from
-        # the same directory, so this step re-sends a symbols package nuget.org
-        # is still validating. Without --skip-duplicate that second PUT is a 409
-        # and fails the job after the package is already live (contracts-v0.12.0,
-        # run 34430841560), skipping the GitHub Release step. Mirrors publish.yml.
-        run: |
-          for package in ./packages/*.snupkg; do
-            if [ -f "$package" ]; then
-              echo "Pushing symbols $package..."
-              dotnet nuget push "$package" \
-                --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
-                --source https://api.nuget.org/v3/index.json \
-                --skip-duplicate
-            fi
           done
 
       - name: Create GitHub Release

--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -238,13 +238,19 @@ jobs:
           done
 
       - name: Push symbols
+        # `dotnet nuget push <pkg>.nupkg` already pushes the paired .snupkg from
+        # the same directory, so this step re-sends a symbols package nuget.org
+        # is still validating. Without --skip-duplicate that second PUT is a 409
+        # and fails the job after the package is already live (contracts-v0.12.0,
+        # run 34430841560), skipping the GitHub Release step. Mirrors publish.yml.
         run: |
           for package in ./packages/*.snupkg; do
             if [ -f "$package" ]; then
               echo "Pushing symbols $package..."
               dotnet nuget push "$package" \
                 --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
-                --source https://api.nuget.org/v3/index.json
+                --source https://api.nuget.org/v3/index.json \
+                --skip-duplicate
             fi
           done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,11 @@ packages/                       # NuGet package output
 - **Authentication**: Not applicable (library, not service)
 - **Secrets Management**: No secrets stored in repository
 - **External APIs**: Library consumers configure LLM providers via Microsoft.Extensions.AI
-- **NuGet Publishing**: GitHub Actions trusted publishing (OIDC via `NuGet/login@v1`); short-lived nuget.org keys. Username is repo var `NUGET_USER`.
+- **NuGet Publishing**: GitHub Actions trusted publishing (OIDC via `NuGet/login@v1`); short-lived nuget.org keys. Repo var `NUGET_USER` is the nuget.org username of the person who *created* the two Trusted Publishing policies (`rsalus`), not the `lvlup` organization that owns the packages and the policies; the token exchange is a 401 otherwise.
 
 ## Known Tech Debt
 
-- Two nuget.org Trusted Publishing policies (`publish.yml`, `publish-contracts.yml`) and repo var `NUGET_USER` must exist before the next `v*` / `contracts-v*` tag. Delete the `NUGET_API_KEY` Actions secret only after a green tag.
+- None. The two nuget.org Trusted Publishing policies (`publish.yml`, `publish-contracts.yml`, environment `nuget-publish`) went live with `contracts-v0.12.0` and `v3.0.0-rc.1` on 2026-09-09, and the long-lived `NUGET_API_KEY` secret was deleted afterwards.
 
 ## Scan Preferences
 

--- a/docs/coordination/2026-09-09-3.0.0-rc.1-consumer-upgrade.md
+++ b/docs/coordination/2026-09-09-3.0.0-rc.1-consumer-upgrade.md
@@ -1,8 +1,9 @@
 # Strategos 3.0.0-rc.1 + Contracts 0.12.0 consumer-upgrade notice
 
 **Date:** 2026-09-09
-**Status:** Consumer set verified 2026-09-09 against each repository's dependency
-manifest; release order decided; adoption issues partially filed (see *Issues*).
+**Status:** Released 2026-09-09. `contracts-v0.12.0` and `v3.0.0-rc.1` both tag
+`f7a7264`; Contracts 0.12.0 and the thirteen product packages are listed on nuget.org.
+Adoption issues are filed in all four consumers (see *Issues*).
 
 Strategos moves **2.10.0 → 3.0.0-rc.1** as a single major pre-release. It carries
 everything merged since 2.10.0 (2026-08-07): the correctness-core program that was
@@ -82,6 +83,20 @@ so every dispatch site in basileus is a compile error until a principal is
 threaded from its identity seam.
 
 ## Issues
+
+Filed 2026-09-09, after both tags published, one per consumer; each supersedes the
+partial issues listed against it:
+
+- **lvlup-sw/basileus#496** (supersedes basileus#492, #489)
+- **lvlup-sw/exarchos#1901** (supersedes exarchos#1892, #1895; pairs with the
+  drift-filed exarchos#1900 builder-API re-baseline)
+- **lvlup-sw/valkyrie#115** (supersedes valkyrie#114, #111); valkyrie goes first
+- **lvlup-sw/dynatoi#59** (supersedes dynatoi#58, #56); dynatoi follows valkyrie
+
+The pins were re-read at filing time: valkyrie is on **2.8.0** (not "around
+2.6–2.7" as the sweep below says), so it absorbs 2.9.0, 2.10.0 and 3.0 in one move.
+
+What the sweep found before filing:
 
 - **lvlup-sw/basileus#492** and **lvlup-sw/exarchos#1892** exist, but they cover
   **only** the #168 typed-predicate delta and Contracts 0.10.0. Neither covers the

--- a/docs/coordination/2026-09-09-3.0.0-rc.1-consumer-upgrade.md
+++ b/docs/coordination/2026-09-09-3.0.0-rc.1-consumer-upgrade.md
@@ -74,7 +74,7 @@ valkyrie, dynatoi); their exposure to this release differs sharply.
 |---|---|---|---|
 | `lvlup-sw/basileus` | `LevelUp.Strategos` **2.9.1** and `LevelUp.Strategos.Contracts` **0.4.0**, both in `Directory.Packages.props` (last touched 2026-08-08). | Core workflow package, generators, Contracts (direct pin *and* transitive). | **Notify; largest delta.** Absorbs 2.10.0 *and* 3.0. Bump the direct Contracts pin to 0.12.0 and the core pin to 3.0.0-rc.1 in **one commit** — transitive pinning is off, so a split graph fails `GateClassSourceTests`, which asserts a singleton Contracts version across every `project.assets.json`. Then work the migration guide top to bottom: Contracts first, correctness core (`Phase` ordinal check, `ValidTransitions`, `AGWF003`), principals, authority, frames, typed contracts, bindings, compensation, cache rollover. |
 | `lvlup-sw/exarchos` | **No Strategos NuGet package at all.** `package.json` carries no Strategos dependency. | Its `strategos-contracts` authority in `src/contract/contract-authority.lock.json` is a **hand-written Zod stand-in** (`src/architecture/invariant-schema.ts`, `src/contract/ir/admission-ir.ts`) pinned at exarchos's *own* package version — not a pin on `LevelUp.Strategos.Contracts`. | **Notify for the schema delta only.** No package to bump. The stand-in should be re-derived from the 0.12.0 schemas if exarchos wants to accept 3.0 producers' workflow JSON (`action`, `compensation.inverseAction`) or the `AGWF035`–`AGWF045` tokens. The `AgwfCode` TypeScript enum the Strategos docs once claimed exarchos round-trips against does not exist (see the 2026-08-23 notice). |
-| `lvlup-sw/valkyrie` | `LevelUp.Strategos.Ontology` and `LevelUp.Strategos.Ontology.MCP`, around **2.6–2.7**. | Ontology-only; no workflow package, no Contracts. | **Notify.** Sections 5–21 of the migration guide apply: mandatory `ActionPrincipal` on `ActionContext` / `ObjectSet.ApplyAsync` / `OntologyActionTool.ExecuteAsync`, `IActionPrincipalResolver` if it hosts MCP, relation enforcement at dispatch, authority lattice, frames, typed predicates with `ActionSubject`, graph-hash rollover. It also absorbs the 2.8–2.10 ontology changes it has not taken yet. |
+| `lvlup-sw/valkyrie` | `LevelUp.Strategos.Ontology`, `LevelUp.Strategos.Ontology.MCP` and `LevelUp.Strategos.Ontology.Npgsql` at **2.8.0** (`src/Valkyrie/Directory.Packages.props`, read 2026-09-09 at filing time). | Ontology-only; no workflow package, no Contracts. | **Notify.** Sections 5–21 of the migration guide apply: mandatory `ActionPrincipal` on `ActionContext` / `ObjectSet.ApplyAsync` / `OntologyActionTool.ExecuteAsync`, `IActionPrincipalResolver` if it hosts MCP, relation enforcement at dispatch, authority lattice, frames, typed predicates with `ActionSubject`, graph-hash rollover. It also absorbs the 2.9.0 and 2.10.0 ontology changes it has not taken yet. |
 | `lvlup-sw/dynatoi` | The five `LevelUp.Strategos.Ontology*` packages at **2.7.0**. | Ontology-only (including MCP and Npgsql); no workflow package, no Contracts. | **Notify.** Same ontology delta as valkyrie, plus its custom `IObjectSetProvider` implementations must be checked against the 2.8–3.0 provider surface (`ActionSubject`-carrying `ObjectSet<T>` construction, principal-threaded `ApplyAsync`). |
 
 Basileus's mandatory-principal exposure is worth stating separately: the
@@ -93,8 +93,8 @@ partial issues listed against it:
 - **lvlup-sw/valkyrie#115** (supersedes valkyrie#114, #111); valkyrie goes first
 - **lvlup-sw/dynatoi#59** (supersedes dynatoi#58, #56); dynatoi follows valkyrie
 
-The pins were re-read at filing time: valkyrie is on **2.8.0** (not "around
-2.6–2.7" as the sweep below says), so it absorbs 2.9.0, 2.10.0 and 3.0 in one move.
+The pins were re-read at filing time; valkyrie is on **2.8.0**, so it absorbs 2.9.0,
+2.10.0 and 3.0 in one move.
 
 What the sweep found before filing:
 
@@ -135,9 +135,9 @@ re-pointed there before the link goes stale in someone's checkout.
 
 Things this notice did **not** verify; treat them as open rather than as absent.
 
-- The exact valkyrie pin. "Around 2.6–2.7" is what the manifest read at a glance;
-  the precise version, and whether valkyrie carries any transitive Contracts
-  reference through a package this sweep did not open, were not confirmed.
+- Whether valkyrie carries any transitive Contracts reference through a package
+  this sweep did not open. (Its direct pin is confirmed: 2.8.0, read from
+  `src/Valkyrie/Directory.Packages.props` when the adoption issue was filed.)
 - Whether dynatoi's custom `IObjectSetProvider` implementations compile against
   the 2.8–3.0 provider surface. Only the package pins were read, not the
   implementations.


### PR DESCRIPTION
Three small follow-ups from cutting `contracts-v0.12.0` and `v3.0.0-rc.1` on 2026-09-09, the first tags published through nuget.org Trusted Publishing.

## What happened

1. **`publish-contracts.yml` failed after the package was live.** `dotnet nuget push X.nupkg` already pushes the paired `.snupkg` from the same directory, so the separate "Push symbols" step re-sent a symbols package nuget.org was still validating. That second PUT was a 409 that failed the job (run [34430841560](https://github.com/lvlup-sw/strategos/actions/runs/34430841560)) and skipped the GitHub Release step; the release was created by hand. The step is removed rather than taught to skip duplicates: `CodegenGuardTests.ContractsRelease_RegeneratesAndTestsBeforePack` forbids duplicate-skipping anywhere in this workflow so that a duplicate *package* push can never turn different local bytes into a green release, and that invariant should stand. The push step now documents why there is no symbols step.
2. **`v3.0.0-rc.1` was briefly the stable "Latest" release.** `project-automation.yml` has a `release` job that creates a GitHub Release on every `v*` tag with git-cliff notes and no prerelease flags, minutes before `publish.yml`'s own release step updates the same release. Carry the hyphen-derived `prerelease` / `make_latest` flags there as well, so the window closes.
3. **`NUGET_USER` had to be the policy creator.** The first Contracts attempt failed the token exchange with `No matching trust policy owned by user 'lvlup'`: the two policies are owned by the `lvlup` organization but were created by `rsalus`, and `NuGet/login` wants the creator's username. The variable now reads `rsalus`; the AGENTS.md Security note says so, and the Known Tech Debt entry is cleared because both policies are proven and the long-lived `NUGET_API_KEY` secret has been deleted.

## Verification

- Contracts 0.12.0: run 34430841560 (attempt 2) pushed the package through OIDC; listed on nuget.org at 03:02Z.
- Product 3.0.0-rc.1: run [34430843324](https://github.com/lvlup-sw/strategos/actions/runs/34430843324) (attempt 2) green end to end; thirteen packages pushed, the Contracts nupkg excluded as intended.
- No workflow references `secrets.NUGET_API_KEY`; `gh secret list` no longer shows it.

Refs #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
