### PR TITLE
fix(ontology): carry the producing descriptor name through chained in-memory hops (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **In-memory chained traversal keeps the producing descriptor's identity (#128).**
+  `InMemoryExpressionEvaluator` resolved the source of a chained hop from the prior hop's
+  CLR-simple type name and the source of a post-narrow hop from the interface's CLR name, so
+  `.TraverseLink<TEdge>("link").Where(...).TraverseLink<TNode>("To")` over an association
+  registered under an alias (or one of several registrations of one CLR type), and
+  `.OfInterface<TInterface>().TraverseLink<T>("link")`, both failed with
+  `Object type '<CLR name>' not found in ontology graph`. The evaluator now carries the
+  graph-resolved descriptor name (`TraverseLinkExpression.RootObjectTypeName`) through the
+  chain and treats an interface narrow as transparent, matching the Npgsql provider. No
+  public API change.
+
 ## [3.0.0-rc.1] - 2026-09-09
 
 The first release since 2.10.0. It folds three milestones that were merged but never

--- a/src/Strategos.Ontology.Tests/Integration/RationaleOntologyFixture.cs
+++ b/src/Strategos.Ontology.Tests/Integration/RationaleOntologyFixture.cs
@@ -88,7 +88,10 @@ public sealed class RationaleOntologyFixture
     // link (target = the association, via its SymbolKey) surfaces the reified
     // edge object with its attributes; a far-node link (target = a node, via the
     // node's SymbolKey) resolves the related node. Both route through the reverse
-    // index — no chained alias-loss hop is needed (that limitation is #128).
+    // index as single hops. The corpus predates the chained-hop fix (#128, now
+    // carried through the in-memory chain) and deliberately keeps its edge-view
+    // rows endpoint-free ("n/a" target ids), so a chained far-endpoint hop is
+    // pinned by InMemoryTraversalIdentityTests rather than by this fixture.
     public const string LinkSupersedesEdge = "supersedesEdge";
     public const string LinkSupersededDecision = "supersededDecision";
     public const string LinkMotivatesEdge = "motivatesEdge";

--- a/src/Strategos.Ontology.Tests/ObjectSets/InMemoryTraversalIdentityTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/InMemoryTraversalIdentityTests.cs
@@ -1,4 +1,5 @@
 using Strategos.Ontology.Actions;
+using Strategos.Ontology.Builder;
 using Strategos.Ontology.Descriptors;
 using Strategos.Ontology.Events;
 using Strategos.Ontology.ObjectSets;
@@ -290,6 +291,106 @@ public class InMemoryTraversalIdentityTests
             .WithMessageContaining("descriptor-name traversal overload");
     }
 
+    // -----------------------------------------------------------------------
+    // #128, second half: the PRODUCING descriptor name is carried through a
+    // chained hop. The front end resolves each hop's target from the graph and
+    // stores it on TraverseLinkExpression.TargetDescriptorName; the NEXT hop's
+    // source descriptor must be THAT name, never the prior hop's CLR-simple type
+    // name, which diverges from the descriptor name the moment the producing
+    // descriptor is registered under an alias. Likewise an interface narrow
+    // never changes the producing descriptor: the evaluator's index holds object
+    // types only, so an interface name (aliased or not) is never a source.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task ChainedHop_AfterAliasedAssociationHop_ResolvesSourceAsProducingDescriptor()
+    {
+        // Arrange — the association is registered under "alias_edges", NOT its
+        // CLR name "AliasEdge". x --active--> y1 and x --inactive--> y2, each
+        // via an attributed relate whose edge object lives in "alias_edges".
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<AliasedEdgeOntology>();
+        var graph = graphBuilder.Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        var query = new OntologyQueryService(
+            graph,
+            provider,
+            Substitute.For<IActionDispatcher>(),
+            Substitute.For<IEventStreamProvider>());
+
+        provider.Seed(new AliasNode("x"), "x", nameof(AliasNode));
+        provider.Seed(new AliasNode("y1"), "y1", nameof(AliasNode));
+        provider.Seed(new AliasNode("y2"), "y2", nameof(AliasNode));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            nameof(AliasNode), "x", AliasedEdgeOntology.LinkName, nameof(AliasNode), "y1",
+            AliasedEdgeOntology.EdgeDescriptor,
+            new AliasEdge("e1", new AliasNode("x"), new AliasNode("y1"), "active"));
+        await writer.RelateAsync(
+            nameof(AliasNode), "x", AliasedEdgeOntology.LinkName, nameof(AliasNode), "y2",
+            AliasedEdgeOntology.EdgeDescriptor,
+            new AliasEdge("e2", new AliasNode("x"), new AliasNode("y2"), "inactive"));
+
+        // Act — edge view (the front end resolves it to "alias_edges"), filter on
+        // the edge attribute, then hop to the far endpoint. The far hop's SOURCE
+        // must resolve as "alias_edges" — the producing descriptor — which is the
+        // only name the evaluator's index knows; "AliasEdge" is not a descriptor.
+        var activeFar = await query
+            .GetObjectSet<AliasNode>(nameof(AliasNode))
+            .Where(n => n.Id == "x")
+            .TraverseLink<AliasEdge>(AliasedEdgeOntology.LinkName)
+            .Where(e => e.Status == "active")
+            .TraverseLink<AliasNode>("To")
+            .ExecuteAsync();
+
+        // Assert — only the ACTIVE edge's far node: the edge filter survived the
+        // chained hop, and the hop routed through the aliased partition.
+        var ids = activeFar.Items.Select(n => n.Id).ToList();
+        await Assert.That(ids).IsEquivalentTo(new[] { "y1" });
+    }
+
+    [Test]
+    public async Task ChainedHop_AfterAliasedInterfaceNarrow_ResolvesSourceThroughTheNarrow()
+    {
+        // Arrange — the interface is registered under "Narrowable", not its CLR
+        // name "INarrowable". x --link--> y; z is an UNRELATED node of the same
+        // type, so the result also proves the hop stayed instance-anchored.
+        var graphBuilder = new OntologyGraphBuilder();
+        graphBuilder.AddDomain<NarrowableNodeOntology>();
+        var graph = graphBuilder.Build();
+
+        var provider = new InMemoryObjectSetProvider(graph);
+        var query = new OntologyQueryService(
+            graph,
+            provider,
+            Substitute.For<IActionDispatcher>(),
+            Substitute.For<IEventStreamProvider>());
+
+        provider.Seed(new NarrowNode("x"), "x", nameof(NarrowNode));
+        provider.Seed(new NarrowNode("y"), "y", nameof(NarrowNode));
+        provider.Seed(new NarrowNode("z"), "z", nameof(NarrowNode));
+
+        IObjectSetWriter writer = provider;
+        await writer.RelateAsync(
+            nameof(NarrowNode), "x", NarrowableNodeOntology.LinkName, nameof(NarrowNode), "y");
+
+        // Act — narrow to the interface, then traverse. The traversal's SOURCE
+        // descriptor must resolve THROUGH the narrow to the root's "NarrowNode";
+        // neither "INarrowable" nor "Narrowable" is an object-type descriptor.
+        var result = await query
+            .GetObjectSet<NarrowNode>(nameof(NarrowNode))
+            .Where(n => n.Id == "x")
+            .OfInterface<INarrowable>()
+            .TraverseLink<NarrowNode>(NarrowableNodeOntology.LinkName)
+            .ExecuteAsync();
+
+        // Assert — exactly {y}: not the unrelated z, and no descriptor-not-found.
+        var ids = result.Items.Select(n => n.Id).ToList();
+        await Assert.That(ids).IsEquivalentTo(new[] { "y" });
+    }
+
     // Graph where the Origin link declares a NODE target (Origin) but the relate
     // is attributed by an association whose CLR type backs TWO descriptors
     // (EdgeWrong first, EdgeRight second). Disambiguation requires an explicit
@@ -353,3 +454,69 @@ public class InMemoryTraversalIdentityTests
 // A distinct CLR type for the source so it never collides with MultiEdge in
 // the type→descriptor reverse index.
 public sealed record OriginNode(string Key);
+
+// ---------------------------------------------------------------------------
+// Chained-hop identity corpus (#128, second half). Self-contained CLR shapes so
+// the aliased registrations below never collide with another file's ontology.
+// ---------------------------------------------------------------------------
+
+public sealed record AliasNode(string Id);
+
+// Reified association whose DESCRIPTOR name ("alias_edges") differs from its
+// CLR name. Endpoints From (role index 0) and To (role index 1).
+public sealed record AliasEdge(string Id, AliasNode From, AliasNode To, string Status);
+
+public sealed class AliasedEdgeOntology : DomainOntology
+{
+    public const string EdgeDescriptor = "alias_edges";
+    public const string LinkName = "link";
+
+    public override string DomainName => "alias";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Object<AliasNode>(obj =>
+        {
+            obj.Key(n => n.Id);
+            obj.HasMany<AliasNode>(LinkName);
+        });
+
+        builder.Association<AliasEdge>(EdgeDescriptor, a =>
+        {
+            a.Key(e => e.Id);
+            a.Between(e => e.From).And(e => e.To);
+            a.Property(e => e.Status).Required();
+        });
+    }
+}
+
+public interface INarrowable
+{
+    string Id { get; }
+}
+
+public sealed record NarrowNode(string Id) : INarrowable;
+
+// The interface DESCRIPTOR name ("Narrowable") differs from its CLR name.
+public sealed class NarrowableNodeOntology : DomainOntology
+{
+    public const string InterfaceDescriptor = "Narrowable";
+    public const string LinkName = "link";
+
+    public override string DomainName => "narrow";
+
+    protected override void Define(IOntologyBuilder builder)
+    {
+        builder.Interface<INarrowable>(InterfaceDescriptor, iface =>
+        {
+            iface.Property(i => i.Id);
+        });
+
+        builder.Object<NarrowNode>(obj =>
+        {
+            obj.Key(n => n.Id);
+            obj.HasMany<NarrowNode>(LinkName);
+            obj.Implements<INarrowable>(map => { });
+        });
+    }
+}

--- a/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
+++ b/src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs
@@ -371,13 +371,19 @@ public class SymbolKeyOnlyTraversalTests
 }
 
 // ---------------------------------------------------------------------------
-// F-MED-2 (DR-9, deferred): polyglot association detection is CLR-only.
+// F-MED-2 (DR-9, residual sliver): the implicit edge view over a NODE-target
+// link is CLR-only.
 //
-// IsAssociationType / TryResolveAssociationDescriptor match on ClrType, so a
-// SymbolKey-only (ingested, ClrType == null) association is NOT recognized and
-// its TraverseLink degrades to PLAIN target-endpoint traversal. This pins that
-// documented limitation; polyglot association traversal is tracked under DR-9
-// and intentionally not implemented.
+// When a link declares a plain node target and the caller gives no descriptor
+// name, the evaluator's only way to surface the reified edge is
+// TryResolveSingleAssociationByClrType, which matches association descriptors
+// on ClrType. A SymbolKey-only (ingested, ClrType == null) association can
+// never match, so the hop degrades to PLAIN target-endpoint traversal. This
+// pins that documented limitation: a node-target link attributed by a
+// ClrType == null association still needs an explicit descriptor name (the
+// TraverseLink(link, descriptorName) overload, or a link that targets the
+// association itself) to surface the edge view. Tracked under DR-9;
+// intentionally not implemented here.
 // ---------------------------------------------------------------------------
 
 // A loaded CLR type used only to REQUEST the would-be edge view. The relate-store

--- a/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
+++ b/src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs
@@ -713,31 +713,29 @@ public sealed class InMemoryExpressionEvaluator
     }
 
     // Resolves the descriptor name of the IMMEDIATE upstream element type (not the
-    // chain root). Filters/includes preserve their source's element type, so we
-    // skip them to the nearest PRODUCING node: a traversal produces its linked
-    // type (ObjectType.Name); a root produces its declared descriptor name (which
-    // can differ from ObjectType.Name for a multi-registered type). This is what
-    // lets a chained TraverseLink resolve its source as the IMMEDIATE prior hop —
-    // e.g. an association hop routes through the far-endpoint path rather than
-    // mistaking the chain root for the source.
+    // chain root). Filters/includes/narrows preserve their source's PRODUCING
+    // descriptor, so we skip them to the nearest producing node: a root produces
+    // its declared descriptor name; a prior traversal produces the descriptor its
+    // hop was resolved to. This is what lets a chained TraverseLink resolve its
+    // source as the IMMEDIATE prior hop — e.g. an association hop routes through
+    // the far-endpoint path rather than mistaking the chain root for the source.
     //
-    // ALIAS-LOSS limitation (strategos #128, deferred): a TraverseLinkExpression
-    // hop resolves to traverse.ObjectType.Name, which is the CLR/object-type name
-    // rather than the descriptor ALIAS the prior hop was registered under. After
-    // a hop the descriptor alias is therefore lost, so a subsequent hop whose
-    // source was an aliased (multi-registered) descriptor resolves against the
-    // bare type name and may route to the wrong partition. Threading the prior
-    // hop's descriptor identity (alias-preserving) through the chain is tracked
-    // under strategos #128 (descriptor-identity-through-the-chain) and
-    // intentionally NOT fixed here.
+    // #128: the producing descriptor NAME is carried through the chain. A prior
+    // hop contributes TraverseLinkExpression.RootObjectTypeName — the explicit
+    // TargetDescriptorName the front end resolved from the graph, falling back to
+    // the CLR-simple name only for graphless sets — so an association registered
+    // under an alias (or one of several registrations of one CLR type) keeps its
+    // partition across the next hop. An interface narrow is transparent: the
+    // descriptor index holds object types only, never interfaces, so the narrow's
+    // source is the producing node. Mirrors the Npgsql provider's helper.
     private static string ResolveImmediateSourceDescriptorName(ObjectSetExpression expression) =>
         expression switch
         {
             RootExpression root => root.ObjectTypeName,
-            TraverseLinkExpression traverse => traverse.ObjectType.Name,
+            TraverseLinkExpression traverse => traverse.RootObjectTypeName,
             FilterExpression filter => ResolveImmediateSourceDescriptorName(filter.Source),
             IncludeExpression include => ResolveImmediateSourceDescriptorName(include.Source),
-            InterfaceNarrowExpression narrow => narrow.InterfaceType.Name,
+            InterfaceNarrowExpression narrow => ResolveImmediateSourceDescriptorName(narrow.Source),
             RawFilterExpression raw => ResolveImmediateSourceDescriptorName(raw.Source),
             _ => throw new NotSupportedException(
                 $"Cannot resolve immediate source descriptor from {expression.GetType().Name}"),


### PR DESCRIPTION
## Summary

Closes #128. The remaining half of the issue — descriptor identity lost across a chained in-memory hop — is fixed. `InMemoryExpressionEvaluator.ResolveImmediateSourceDescriptorName` resolved a chained hop's source from CLR names rather than from the descriptor the prior node actually produced, so `.TraverseLink<TEdge>("link").Where(...).TraverseLink<TNode>("To")` over an association registered under an alias (or one of several registrations of one CLR type) failed with `Object type 'TEdge' not found in ontology graph`, and `.OfInterface<TInterface>().TraverseLink<T>("link")` failed with `Object type 'TInterface' not found`.

The first half (association ambiguity under multi-registration) was already closed by #129/#136: `ResolveHopTargetDescriptor` / `TryResolveAssociationHopDescriptor` / `TryResolveSingleAssociationByClrType` plus the front-end `AmbiguousTraversalTarget` refusal and `AONT211`.

## Changes

- `src/Strategos.Ontology/ObjectSets/InMemoryExpressionEvaluator.cs` — two switch arms in `ResolveImmediateSourceDescriptorName`:
  - `TraverseLinkExpression` now yields `traverse.RootObjectTypeName` (the graph-resolved `TargetDescriptorName`, falling back to the CLR-simple name only for graphless sets) instead of `traverse.ObjectType.Name`.
  - `InterfaceNarrowExpression` now recurses into `narrow.Source` instead of yielding `narrow.InterfaceType.Name` — the descriptor index holds `graph.ObjectTypes` only, so that arm could never hit.
  - The "ALIAS-LOSS limitation (deferred)" comment is replaced by a short note that the producing descriptor name is carried through the chain. This now matches `PgVectorObjectSetProvider.ResolveImmediateSourceDescriptorName`, which already did both; its doc comment saying it "mirrors" the in-memory helper is now true and is unchanged.
- `src/Strategos.Ontology.Tests/ObjectSets/InMemoryTraversalIdentityTests.cs` — two new tests with self-contained ontologies (`AliasedEdgeOntology`, `NarrowableNodeOntology`):
  - `ChainedHop_AfterAliasedAssociationHop_ResolvesSourceAsProducingDescriptor` — association registered as `"alias_edges"` (CLR `AliasEdge`), edge-attribute filter, far hop to `"To"`.
  - `ChainedHop_AfterAliasedInterfaceNarrow_ResolvesSourceThroughTheNarrow` — interface registered as `"Narrowable"` (CLR `INarrowable`), narrow then hop.
- `src/Strategos.Ontology.Tests/ObjectSets/ObjectSetTraversalTests.cs` — stale header comment named `IsAssociationType` / `TryResolveAssociationDescriptor`, which no longer exist; it now names `TryResolveSingleAssociationByClrType` and states the residual sliver precisely.
- `src/Strategos.Ontology.Tests/Integration/RationaleOntologyFixture.cs` — the "no chained alias-loss hop is needed (that limitation is #128)" note is updated. No chained hop added to that fixture: it is shared with the Npgsql parity harness and its edge-view rows deliberately carry `"n/a"` target ids, so a chained far-endpoint hop there would need row restructuring across both providers.
- `CHANGELOG.md` — new `## [Unreleased]` / `### Fixed` entry above `3.0.0-rc.1`.

No `PublicAPI` changes; no new fields on expression nodes.

## Test plan

Red-then-green on the unfixed evaluator, then the fix:

```
dotnet run --no-build --project src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj -- --treenode-filter "/*/*/InMemoryTraversalIdentityTests/ChainedHop_*"
# before fix: failed: 2
#   ChainedHop_AfterAliasedAssociationHop…: Object type 'AliasEdge' not found in ontology graph. Available types: AliasNode, alias_edges
#   ChainedHop_AfterAliasedInterfaceNarrow…: Object type 'INarrowable' not found in ontology graph. Available types: NarrowNode
# after fix (whole class): total 7, succeeded 7
```

Full suites after the fix (all `dotnet build` with warnings-as-errors: 0 warnings, 0 errors):

```
dotnet run --project src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj
# total: 1170  failed: 0  succeeded: 1170  skipped: 0

dotnet run --project src/Strategos.Ontology.Npgsql.Tests/Strategos.Ontology.Npgsql.Tests.csproj
# total: 195  failed: 0  succeeded: 180  skipped: 15   (DB tests self-skip without STRATEGOS_PG_TEST_CONN)

dotnet run --project src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj
# total: 45  failed: 0  succeeded: 45  skipped: 0      (ReleaseShapeTests still pass with the CHANGELOG edit)
```

## What this does NOT fix

The residual DR-9 sliver stays pinned by `TraverseLink_OverSymbolKeyOnlyAssociation_DegradesToPlainTargetEndpoint`: when a link declares a plain node target and the caller supplies no descriptor name, the only route to the reified edge view is `TryResolveSingleAssociationByClrType`, which matches on `ClrType`. A SymbolKey-only (`ClrType == null`) association can never match, so that hop degrades to plain target-endpoint traversal; such a link still needs the `TraverseLink(link, descriptorName)` overload (or a link that targets the association itself) to surface the edge view. That is unrelated to chained-hop identity and is left for DR-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
