### PR TITLE
ci: move every GitHub Action to its Node 24 major and re-pin the org reusables

### DIFF
--- a/.github/workflows/benchmark-full.yml
+++ b/.github/workflows/benchmark-full.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -87,21 +87,21 @@ jobs:
           fi
 
       - name: Upload JSON results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-json-${{ github.sha }}
           path: ./benchmark-results/**/*.json
           retention-days: 90
 
       - name: Upload Markdown results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-markdown-${{ github.sha }}
           path: ./benchmark-results/**/*.md
           retention-days: 90
 
       - name: Upload full artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-full-${{ github.sha }}
           path: ./benchmark-results/
@@ -113,13 +113,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout comparison ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.comparison_ref }}
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -140,14 +140,14 @@ jobs:
             --artifacts ./baseline-results
 
       - name: Upload baseline results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-baseline-${{ inputs.comparison_ref }}
           path: ./baseline-results/
           retention-days: 30
 
       - name: Download current results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: benchmark-json-${{ github.sha }}
           path: ./current-results/
@@ -173,13 +173,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: benchmark-markdown-${{ github.sha }}
           path: ./results/
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -33,7 +33,7 @@ jobs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -88,12 +88,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -110,7 +110,7 @@ jobs:
             --artifacts ./benchmark-results
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ github.sha }}
           path: ./benchmark-results/
@@ -134,7 +134,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -84,10 +84,10 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -120,10 +120,10 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -167,12 +167,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: AGAG hygiene (DR-7)
         run: bash scripts/check-agag-hygiene.sh
@@ -221,14 +221,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout with full history (the placement gate diffs against the last v* tag)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -250,10 +250,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,8 @@ jobs:
     # c10269573359bc91ff59fe5e9cb8090bbc6cb87a when this pin was set. A tag is
     # movable, so the SHA is recorded here to make that visible; the reusable
     # SHA-pins its internal actions, so the action graph under this ref is fixed.
-    uses: lvlup-sw/.github/.github/workflows/codeql.yml@v1
+    # Pinned to the same immutable org-workflow revision as ci.yml (the moving v1 tag lags it).
+    uses: lvlup-sw/.github/.github/workflows/codeql.yml@ffd6fb4979fba8a4317cca6fd7ad9ec4090acff9
     with:
       languages: csharp
       build-mode: none

--- a/.github/workflows/contracts-codegen-guard.yml
+++ b/.github/workflows/contracts-codegen-guard.yml
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/contracts-schema-diff.yml
+++ b/.github/workflows/contracts-schema-diff.yml
@@ -28,7 +28,10 @@ on:
       - 'src/Strategos.Contracts/schemas/**'
       - 'src/Strategos.Contracts/Strategos.Contracts.csproj'
       - 'scripts/contracts-schema-diff.mjs'
-      - '.github/workflows/contracts-schema-diff.yml'
+      # This file is deliberately not in its own trigger list: the published arm
+      # requires ContractsVersion to exceed the last published Contracts version,
+      # which is only true while a Contracts change is in flight. A tooling-only
+      # edit here (an action bump) must not demand a Contracts version bump.
 
 permissions:
   contents: read
@@ -44,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,6 +33,7 @@ jobs:
       pull-requests: write
     # Org reusable workflows are pinned to the v1 tag, which resolved to
     # c10269573359bc91ff59fe5e9cb8090bbc6cb87a when this pin was set.
-    uses: lvlup-sw/.github/.github/workflows/dependency-review.yml@v1
+    # Pinned to the same immutable org-workflow revision as ci.yml (the moving v1 tag lags it).
+    uses: lvlup-sw/.github/.github/workflows/dependency-review.yml@ffd6fb4979fba8a4317cca6fd7ad9ec4090acff9
     with:
       fail-on-severity: high

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -39,9 +39,9 @@ jobs:
         run: npm run build
         working-directory: docs
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/dist
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -31,13 +31,13 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install js-yaml
         run: npm install js-yaml
 
       - name: Sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -113,7 +113,7 @@ jobs:
       issues: write
     steps:
       - name: Auto-label based on title
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add to project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/lvlup-sw/projects/${{ env.PROJECT_NUMBER }}
           github-token: ${{ secrets.PROJECT_TOKEN }}
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize project fields
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
@@ -385,7 +385,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update project status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
@@ -494,7 +494,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v11
         with:
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had
@@ -535,7 +535,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -551,7 +551,7 @@ jobs:
         # Keep the pre-release flags in step with it: a hyphenated tag
         # (v3.0.0-rc.1) must never be published as a stable "Latest" release
         # in the window before publish.yml's release step runs.
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.content }}
           generate_release_notes: false

--- a/.github/workflows/public-api-drift.yml
+++ b/.github/workflows/public-api-drift.yml
@@ -78,7 +78,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout PR head (full history for the base diff)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for tag diff)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -33,7 +33,7 @@ jobs:
     environment: nuget-publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -50,13 +50,13 @@ jobs:
           fi
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           dotnet-quality: ${{ env.DOTNET_QUALITY }}
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 
@@ -245,7 +245,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./packages/*
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,13 @@ jobs:
     environment: nuget-publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Required for MinVer and git-cliff
           fetch-tags: true  # Explicitly fetch tags for version detection
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           dotnet-quality: ${{ env.DOTNET_QUALITY }}
@@ -120,7 +120,7 @@ jobs:
           args: --latest --strip header
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./packages/*
           body: ${{ steps.changelog.outputs.content }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -25,14 +25,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: TruffleHog Secret Scan
         id: trufflehog
-        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        uses: trufflesecurity/trufflehog@363923b901c911a9164f50b6c423f47c15372b1c # v3.97.4
         continue-on-error: true
         with:
           extra_args: --results=verified

--- a/src/Strategos.Contracts.Tests/Pipeline/CodegenGuardTests.cs
+++ b/src/Strategos.Contracts.Tests/Pipeline/CodegenGuardTests.cs
@@ -362,7 +362,7 @@ public sealed class CodegenGuardTests
         await Assert.That(yaml.Contains("--skip-duplicate", StringComparison.Ordinal)).IsFalse()
             .Because("a duplicate push must not turn different local package bytes into a green release.");
         await Assert.That(yaml).Contains(
-            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020");
+            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020");
         await Assert.That(yaml.Contains("packages: write", StringComparison.Ordinal)).IsFalse();
         await Assert.That(yaml).Contains("persist-credentials: false");
     }

--- a/src/Strategos.Contracts.Tests/Pipeline/SchemaDiffTests.cs
+++ b/src/Strategos.Contracts.Tests/Pipeline/SchemaDiffTests.cs
@@ -920,7 +920,7 @@ public class SchemaDiffTests
         await Assert.That(workflow).Contains("schema compatibility is indeterminate");
         await Assert.That(workflow).Contains("permissions:\n  contents: read");
         await Assert.That(workflow).Contains(
-            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020");
+            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020");
         await Assert.That(workflow).Contains("persist-credentials: false");
 
         // Second arm: the published baseline can be several minors behind, so a


### PR DESCRIPTION
## Summary

Every GitHub Action in `.github/workflows` moves to its current Node 24 major — the fourteen bumps Dependabot proposed in #202 — plus the three things that PR could not carry, which is why it was red.

## What #202 was missing

1. **Two Contracts tests pin the literal `actions/setup-node` SHA** that `contracts-schema-diff.yml` and `publish-contracts.yml` use (`CodegenGuardTests.ContractsRelease_RegeneratesAndTestsBeforePack`, `SchemaDiffTests.SchemaDiff_Workflow_UsesPublishedPackageAndCompleteSchemaTree`). They now expect the v7.0.0 commit `8207627…`, verified against the upstream tag. This was the "Contracts tests (Node toolchain)" failure on #202 (213 total, 2 failed).
2. **`codeql.yml` and `dependency-review.yml` called the org reusables on the moving `v1` tag**, which resolves to `894da6a`, behind the `ffd6fb4` revision the other three reusables are pinned to. All five now use the same immutable revision.
3. **`contracts-schema-diff.yml` listed itself in its own `paths:` trigger.** Its published arm requires `ContractsVersion` to exceed the last published Contracts release, which is only true while a Contracts change is in flight, so any tooling-only edit to that file (an action bump) failed the gate with "candidate version 0.12.0 must be greater than published baseline 0.12.0". The self-reference is removed with a comment saying why.

## Release notes, read for every major

| Action | Bump | Breaking surface | Applies here? |
|---|---|---|---|
| actions/checkout | 4 → 7 | v7 blocks fork checkout on `pull_request_target` / `workflow_run`; v5 Node 24 | no — neither trigger is used |
| actions/setup-dotnet, setup-node, setup-python, configure-pages, deploy-pages | major | Node 24 runtime, no input changes | no |
| actions/upload-artifact | 4 → 7 | Node 24; runner ≥ 2.327.1 | uploads run on `ubuntu-latest` |
| actions/download-artifact | 4 → 8 | v5 single-artifact-by-**id** path change; v8 stops unzipping non-zip content and errors on digest mismatch; ESM | both uses download by **name** from the same run (`benchmark-full.yml`) |
| actions/github-script | 7 → 9 | ESM-only; `getOctokit` injected | no `@actions/github` require or `getOctokit` in the repo |
| actions/upload-pages-artifact | 3 → 5 | v4 drops dotfiles unless `include-hidden-files` | `docs/dist` has none Pages needs |
| actions/add-to-project, actions/stale | 1.0.2 → 2.0.0, 9 → 11 | dependency/ESM moves; stale 10 needs runner ≥ 2.327.1 | GitHub-hosted runners |
| softprops/action-gh-release | 2 → 3 | Node 24 only; inputs unchanged (`files`, `body`, `generate_release_notes`, `prerelease`, `make_latest`) | release path unchanged |
| trufflesecurity/trufflehog | 3.97.1 → 3.97.4 | patch (SHA `363923b…` = v3.97.4) | — |

## Test plan

- `dotnet run --project src/Strategos.Contracts.Tests/... -- --treenode-filter "/*/*/CodegenGuardTests/*"` → 5/5
- `… "/*/*/SchemaDiffTests/*"` → 58/58
- CI on this PR exercises checkout, setup-dotnet, setup-node and github-script directly; the benchmark, docs-deploy and release workflows run on their own triggers and should be watched on first use.

Supersedes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
