### PR TITLE
fix(ontology-npgsql): derive every generated identifier through the 63-byte guard (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graph-resolved descriptor name (`TraverseLinkExpression.RootObjectTypeName`) through the
   chain and treats an interface narrow as transparent, matching the Npgsql provider. No
   public API change.
+- **Every generated Npgsql identifier goes through the 63-byte guard (#130, R3a).** Vertex,
+  junction and association-object table names, `{role}_id` endpoint columns and index names
+  now all derive through one deterministic truncate-and-hash function (`PgIdentifier`, the
+  generalized DR-11 junction guard), so a logical name over PostgreSQL's 63-byte
+  `NAMEDATALEN - 1` limit yields the SAME identifier in the DDL and in the
+  relate/unrelate/traversal DML. Previously only the relate/unrelate write path derived the
+  junction name; the junction DDL, the traversal read and the association-object DDL emitted
+  the raw name, which PostgreSQL silently truncates — a `42P01 relation does not exist` on the
+  first relate over a long `{source}_{link}`, and two long descriptor or role names could
+  collapse onto one table or column. The association endpoint-role collision guard now
+  compares the derived columns. Names within the cap are byte-identical to before.
 
 ## [3.0.0-rc.1] - 2026-09-09
 

--- a/docs/src/content/docs/reference/ontology/npgsql.md
+++ b/docs/src/content/docs/reference/ontology/npgsql.md
@@ -100,6 +100,8 @@ The `descriptorName` parameter resolves the target table:
 - When non-null, the table name is the snake-cased descriptor name (e.g. `"TradingDocuments"` → `"trading_documents"`).
 - When null, resolution falls back to the registered descriptor name for `T` via the optional `OntologyGraph` passed to the provider constructor. For a type registered exactly once, the default works. For a type registered under multiple descriptor names (multi-registration), the default-null call throws — callers must supply `descriptorName` explicitly, one call per descriptor.
 
+Every generated identifier — vertex, junction and association-object table names, `{role}_id` endpoint columns and index names — is capped at PostgreSQL's 63-byte identifier limit (`NAMEDATALEN - 1`): a name within the cap is used verbatim, and a longer one is truncated and given a deterministic hash suffix derived from the full name. The DDL and the relate/unrelate/traversal DML derive each identifier through the same function, so they always agree and two long names never silently collapse onto one table or column.
+
 ## Multi-registration partitioning
 
 The same CLR carrier type can be registered under multiple descriptor names — for example a shared content-carrier registered separately for "trading documents" and "knowledge documents," each backed by an independent table partition. The write path mirrors the read path:

--- a/src/Strategos.Ontology.Npgsql.Tests/Schema/IdentifierGuardTests.cs
+++ b/src/Strategos.Ontology.Npgsql.Tests/Schema/IdentifierGuardTests.cs
@@ -1,5 +1,9 @@
 using System.Text;
+using Strategos.Ontology;
+using Strategos.Ontology.Descriptors;
+using Strategos.Ontology.Npgsql.Internal;
 using Strategos.Ontology.Npgsql.Schema;
+using Strategos.Ontology.ObjectSets;
 
 namespace Strategos.Ontology.Npgsql.Tests.Schema;
 
@@ -104,4 +108,298 @@ public class IdentifierGuardTests
         await Assert.That(() => JunctionIdentifier.Derive(longName, derivedLong))
             .Throws<OntologySchemaIdentifierException>();
     }
+
+    // -----------------------------------------------------------------------
+    // #130 R3a — the guard is applied at EVERY identifier-derivation site. The
+    // DDL and the relate/unrelate/traversal DML must name the SAME physical
+    // object for one logical (source, link) / descriptor / role, and no
+    // generated identifier may exceed the cap. Each test pins a >63-byte
+    // logical name against the production resolvers and SQL builders.
+    // -----------------------------------------------------------------------
+
+    private const string GuardDomain = "guard";
+    private const string ShortTarget = "GuardTarget";
+
+    [Test]
+    public async Task LongMonomorphicJunction_DdlRelateUnrelateAndTraversal_NameTheSameDerivedTable()
+    {
+        // A long source descriptor + a long link: the raw {source}_{link} junction
+        // name is over the 63-byte cap while both vertex names stay within it, so
+        // ONLY the junction identifier is derived — and it must be derived
+        // identically by the DDL, the relate/unrelate write path and the
+        // traversal read path.
+        var sourceName = "GuardSource" + new string('a', 29);
+        var linkName = "GuardLink" + new string('b', 31);
+        var graph = BuildLinkGraph(sourceName, linkName, ShortTarget);
+
+        var sourceTable = TypeMapper.ToSnakeCase(sourceName);
+        var targetTable = TypeMapper.ToSnakeCase(ShortTarget);
+        var rawJunction = $"{sourceTable}_{TypeMapper.ToSnakeCase(linkName)}";
+        await Assert.That(Encoding.UTF8.GetByteCount(sourceTable))
+            .IsLessThanOrEqualTo(PostgresIdentifierByteLimit);
+        await Assert.That(Encoding.UTF8.GetByteCount(rawJunction))
+            .IsGreaterThan(PostgresIdentifierByteLimit);
+
+        var expected = PgIdentifier.Derive(rawJunction);
+        await Assert.That(expected).IsNotEqualTo(rawJunction);
+
+        // DDL — both junction DDL builders create the DERIVED table.
+        var ddl = SqlGenerator.BuildJunctionTableDdl("public", sourceTable, linkName, targetTable);
+        await Assert.That(ddl).Contains($"CREATE TABLE IF NOT EXISTS \"public\".\"{expected}\"");
+        await Assert.That(ddl).DoesNotContain(rawJunction);
+
+        var junction = PgVectorObjectSetProvider.ResolveRelateJunction(
+            graph, srcDescriptor: sourceName, linkName: linkName, tgtDescriptor: ShortTarget);
+        await Assert.That(junction.IsPolymorphic).IsFalse();
+        var resolvedDdl = SqlGenerator.BuildJunctionTableDdlForResolvedTargets("public", [junction]);
+        await Assert.That(resolvedDdl[0]).Contains($"CREATE TABLE IF NOT EXISTS \"public\".\"{expected}\"");
+
+        // Relate / unrelate DML — the write path names the SAME derived table.
+        var relateName = SqlGenerator.JunctionTableNameFor(junction);
+        await Assert.That(relateName).IsEqualTo(expected);
+
+        var relateSql = SqlGenerator.BuildValidatingRelateInsertSql(
+            "public", relateName, junction.SourceTable, "Id", junction.TargetTable, "Id");
+        await Assert.That(relateSql).Contains($"\"public\".\"{expected}\"");
+
+        var unrelateSql = SqlGenerator.BuildUnrelateDeleteSql(
+            "public", relateName, junction.SourceTable, "Id", junction.TargetTable, "Id");
+        await Assert.That(unrelateSql).Contains($"\"public\".\"{expected}\"");
+
+        // Traversal DML — the read path (the pre-#130 drift site) names it too.
+        await Assert.That(SqlGenerator.JunctionTableName(sourceTable, linkName)).IsEqualTo(expected);
+
+        var hop = PgVectorObjectSetProvider.ResolveTraversalHop(
+            graph, sourceDescriptorName: sourceName, linkName: linkName, targetDescriptorOverride: null);
+        await Assert.That(hop.JunctionTable).IsEqualTo(expected);
+
+        var traversalSql = SqlGenerator.BuildInstanceAnchoredTraversalSql(
+            "public", hop.SourceTable, hop.SourceKeyProperty, hop.JunctionTable, hop.TargetTable);
+        await Assert.That(traversalSql).Contains($"JOIN \"public\".\"{expected}\" j");
+        await Assert.That(traversalSql).DoesNotContain(rawJunction);
+    }
+
+    [Test]
+    public async Task LongAssociationDescriptor_DdlAndRelateDml_NameTheSameDerivedTableAndIndex()
+    {
+        // A long association descriptor AND a long endpoint descriptor: the
+        // association-object table, its as-of-now index and the endpoint's FK
+        // target are all over the cap and must all be derived — identically by
+        // the DDL and by the attributed-relate plan the DML is built from.
+        var assocName = "GuardEmployment" + new string('c', 55);
+        var leftName = "GuardLeft" + new string('d', 61);
+        var graph = BuildAssociationGraph(assocName, "From", leftName, "To", ShortTarget);
+        var association = graph.ObjectTypes.Single(o => o.Name == assocName);
+
+        var rawTable = TypeMapper.ToSnakeCase(assocName);
+        var rawLeft = TypeMapper.ToSnakeCase(leftName);
+        await Assert.That(Encoding.UTF8.GetByteCount(rawTable)).IsGreaterThan(PostgresIdentifierByteLimit);
+        await Assert.That(Encoding.UTF8.GetByteCount(rawLeft)).IsGreaterThan(PostgresIdentifierByteLimit);
+
+        var expectedTable = PgIdentifier.Derive(rawTable);
+        var expectedLeft = PgIdentifier.Derive(rawLeft);
+        var expectedIndex = PgIdentifier.Derive($"idx_{expectedTable}_as_of_now");
+        await Assert.That(Encoding.UTF8.GetByteCount(expectedIndex))
+            .IsLessThanOrEqualTo(PostgresIdentifierByteLimit);
+
+        var ddl = SqlGenerator.BuildAssociationObjectTableDdl("public", association);
+        await Assert.That(ddl).Contains($"CREATE TABLE IF NOT EXISTS \"public\".\"{expectedTable}\"");
+        await Assert.That(ddl).Contains($"REFERENCES \"public\".\"{expectedLeft}\" (id)");
+        await Assert.That(ddl).Contains($"CREATE INDEX IF NOT EXISTS \"{expectedIndex}\"");
+        await Assert.That(ddl).DoesNotContain(rawTable);
+        await Assert.That(ddl).DoesNotContain(rawLeft);
+
+        var plan = PgVectorObjectSetProvider.ResolveAssociationRelate(
+            graph, associationDescriptor: assocName, srcDescriptor: leftName, tgtDescriptor: ShortTarget);
+        await Assert.That(plan.AssociationTable).IsEqualTo(expectedTable);
+        await Assert.That(plan.SourceTable).IsEqualTo(expectedLeft);
+
+        var insert = SqlGenerator.BuildAssociationRelateInsertSql(
+            "public",
+            plan.AssociationTable,
+            plan.SourceColumn,
+            plan.SourceTable,
+            plan.SourceKeyProperty,
+            plan.TargetColumn,
+            plan.TargetTable,
+            plan.TargetKeyProperty);
+        await Assert.That(insert).Contains($"INSERT INTO \"public\".\"{expectedTable}\"");
+        await Assert.That(insert).Contains($"\"public\".\"{expectedLeft}\"");
+
+        var asOf = SqlGenerator.BuildAsOfTransactionTimeSql("public", plan.AssociationTable);
+        await Assert.That(asOf).Contains($"FROM \"public\".\"{expectedTable}\"");
+    }
+
+    [Test]
+    public async Task LongVertexDescriptor_EveryTableNameResolverAndTheDdl_UseTheSameDerivedTable()
+    {
+        // A long vertex descriptor: every table-name resolver the provider routes
+        // through (read path, explicit-name write path, schema bootstrap, relate
+        // endpoint, default overload) must agree on ONE derived identifier, and
+        // the vertex DDL must create that table with capped index names.
+        var vertexName = "GuardVertex" + new string('e', 60);
+        var raw = TypeMapper.ToSnakeCase(vertexName);
+        await Assert.That(Encoding.UTF8.GetByteCount(raw)).IsGreaterThan(PostgresIdentifierByteLimit);
+
+        var expected = PgIdentifier.Derive(raw);
+        await Assert.That(expected).IsNotEqualTo(raw);
+        var graph = BuildLinkGraph(vertexName, "GuardLink", ShortTarget);
+
+        await Assert.That(PgVectorObjectSetProvider.ResolveTableName(
+                new RootExpression(typeof(GuardSourceNode), vertexName)))
+            .IsEqualTo(expected);
+        await Assert.That(PgVectorObjectSetProvider.ResolveTableNameForDescriptor(vertexName))
+            .IsEqualTo(expected);
+        await Assert.That(PgVectorObjectSetProvider.ResolveEnsureSchemaTableName<GuardSourceNode>(vertexName, graph: null))
+            .IsEqualTo(expected);
+        await Assert.That(PgVectorObjectSetProvider.ResolveTableNameForDefaultOverload<GuardSourceNode>(graph))
+            .IsEqualTo(expected);
+        await Assert.That(PgVectorObjectSetProvider.ResolveRelateEndpoint(graph, vertexName).TableName)
+            .IsEqualTo(expected);
+
+        var ddl = SqlGenerator.BuildSchemaCreationDdl(
+            "public", expected, 3, PgVectorIndexType.Hnsw, keyPropertyName: "Id");
+        await Assert.That(ddl).Contains($"CREATE TABLE IF NOT EXISTS \"public\".\"{expected}\"");
+
+        // The embedding index is named from the (already-capped) table name and
+        // must itself stay within the cap.
+        var embeddingIndex = PgIdentifier.Derive($"idx_{expected}_embedding");
+        await Assert.That(Encoding.UTF8.GetByteCount(embeddingIndex))
+            .IsLessThanOrEqualTo(PostgresIdentifierByteLimit);
+        await Assert.That(ddl).Contains($"CREATE INDEX IF NOT EXISTS \"{embeddingIndex}\"");
+    }
+
+    [Test]
+    public async Task LongEndpointRoles_SharingA63BytePrefix_DeriveDistinctCappedColumnsInDdlAndDml()
+    {
+        // Two roles whose {role}_id columns are over the cap and IDENTICAL in their
+        // first 63 bytes — exactly what PostgreSQL would silently collapse into a
+        // duplicate column. The derived columns must be distinct, capped, and the
+        // same in the DDL and the attributed-relate DML.
+        var sharedRole = "GuardRole" + new string('f', 56);
+        var roleA = sharedRole + "Alpha";
+        var roleB = sharedRole + "Beta";
+        var rawA = $"{TypeMapper.ToSnakeCase(roleA)}_id";
+        var rawB = $"{TypeMapper.ToSnakeCase(roleB)}_id";
+        await Assert.That(Encoding.UTF8.GetByteCount(rawA)).IsGreaterThan(PostgresIdentifierByteLimit);
+        await Assert.That(rawA[..PostgresIdentifierByteLimit]).IsEqualTo(rawB[..PostgresIdentifierByteLimit]);
+
+        var expectedA = PgIdentifier.Derive(rawA);
+        var expectedB = PgIdentifier.Derive(rawB);
+        await Assert.That(expectedA).IsNotEqualTo(expectedB);
+
+        const string pairing = "GuardPairing";
+        var graph = BuildAssociationGraph(pairing, roleA, "GuardLeft", roleB, ShortTarget);
+        var association = graph.ObjectTypes.Single(o => o.Name == pairing);
+
+        var ddl = SqlGenerator.BuildAssociationObjectTableDdl("public", association);
+        await Assert.That(ddl).Contains($"\"{expectedA}\" uuid NOT NULL");
+        await Assert.That(ddl).Contains($"\"{expectedB}\" uuid NOT NULL");
+        await Assert.That(ddl).DoesNotContain(rawA);
+        await Assert.That(ddl).DoesNotContain(rawB);
+
+        var plan = PgVectorObjectSetProvider.ResolveAssociationRelate(
+            graph, associationDescriptor: pairing, srcDescriptor: "GuardLeft", tgtDescriptor: ShortTarget);
+        await Assert.That(plan.SourceColumn).IsEqualTo(expectedA);
+        await Assert.That(plan.TargetColumn).IsEqualTo(expectedB);
+
+        var insert = SqlGenerator.BuildAssociationRelateInsertSql(
+            "public",
+            plan.AssociationTable,
+            plan.SourceColumn,
+            plan.SourceTable,
+            plan.SourceKeyProperty,
+            plan.TargetColumn,
+            plan.TargetTable,
+            plan.TargetKeyProperty);
+        await Assert.That(insert).Contains($"(id, data, \"{expectedA}\", \"{expectedB}\")");
+
+        // Roles that normalize to the SAME column (a case-only difference) are
+        // still refused with the typed normalization-collision error — the guard
+        // compares DERIVED columns, so it can never let two roles silently merge.
+        var colliding = new ObjectTypeDescriptor
+        {
+            Name = "GuardCollide",
+            DomainName = GuardDomain,
+            ClrType = typeof(GuardEdge),
+            KeyProperty = new PropertyDescriptor("Id", typeof(string)),
+            Kind = ObjectKind.Association,
+            AssociationEndpoints =
+            [
+                new AssociationEndpoint("Owner", "GuardLeft"),
+                new AssociationEndpoint("owner", ShortTarget),
+            ],
+        };
+        await Assert.That(() => SqlGenerator.BuildAssociationObjectTableDdl("public", colliding))
+            .Throws<ArgumentException>();
+    }
+
+    // -----------------------------------------------------------------------
+    // Graph fixtures — built through the internal OntologyGraph constructor so a
+    // descriptor/link/role name of arbitrary length can be pinned directly.
+    // -----------------------------------------------------------------------
+
+    private static OntologyGraph BuildLinkGraph(string sourceName, string linkName, string targetName)
+    {
+        var source = new ObjectTypeDescriptor
+        {
+            Name = sourceName,
+            DomainName = GuardDomain,
+            ClrType = typeof(GuardSourceNode),
+            KeyProperty = new PropertyDescriptor("Id", typeof(string)),
+            Links = [new LinkDescriptor(linkName, targetName, LinkCardinality.OneToMany)],
+        };
+
+        return BuildGraph(source, Vertex(targetName, typeof(GuardTargetNode)));
+    }
+
+    private static OntologyGraph BuildAssociationGraph(
+        string associationName, string leftRole, string leftName, string rightRole, string rightName)
+    {
+        var association = new ObjectTypeDescriptor
+        {
+            Name = associationName,
+            DomainName = GuardDomain,
+            ClrType = typeof(GuardEdge),
+            KeyProperty = new PropertyDescriptor("Id", typeof(string)),
+            Kind = ObjectKind.Association,
+            AssociationEndpoints =
+            [
+                new AssociationEndpoint(leftRole, leftName),
+                new AssociationEndpoint(rightRole, rightName),
+            ],
+        };
+
+        return BuildGraph(
+            Vertex(leftName, typeof(GuardSourceNode)),
+            Vertex(rightName, typeof(GuardTargetNode)),
+            association);
+    }
+
+    private static ObjectTypeDescriptor Vertex(string name, Type clrType) => new()
+    {
+        Name = name,
+        DomainName = GuardDomain,
+        ClrType = clrType,
+        KeyProperty = new PropertyDescriptor("Id", typeof(string)),
+    };
+
+    private static OntologyGraph BuildGraph(params ObjectTypeDescriptor[] objectTypes) => new(
+        domains: [new DomainDescriptor(GuardDomain) { ObjectTypes = objectTypes }],
+        objectTypes: objectTypes,
+        interfaces: [],
+        crossDomainLinks: [],
+        workflowChains: [],
+        objectTypeNamesByType: objectTypes
+            .Where(o => o.ClrType is not null)
+            .GroupBy(o => o.ClrType!)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<string>)g.Select(o => o.Name).ToList()));
 }
+
+// Distinct CLR carriers so the type->descriptor reverse index resolves each
+// long-named descriptor unambiguously in the default-overload resolver.
+public sealed record GuardSourceNode(string Id);
+
+public sealed record GuardTargetNode(string Id);
+
+public sealed record GuardEdge(string Id);

--- a/src/Strategos.Ontology.Npgsql/Internal/SqlGenerator.cs
+++ b/src/Strategos.Ontology.Npgsql/Internal/SqlGenerator.cs
@@ -258,7 +258,9 @@ internal static class SqlGenerator
             _ => throw new ArgumentOutOfRangeException(nameof(indexType), indexType, "Unsupported pgvector index type."),
         };
 
-        var indexName = QuoteIdentifier($"idx_{tableName}_embedding");
+        // #130 R3a: the index name is derived from the (already-capped) table name
+        // and can itself exceed the cap, so it goes through the same guard.
+        var indexName = QuoteIdentifier(PgIdentifier.Derive($"idx_{tableName}_embedding"));
         sb.Append($"CREATE INDEX IF NOT EXISTS {indexName} ON {QuoteIdentifier(schema)}.{QuoteIdentifier(tableName)} USING {indexMethod} (embedding {opsClass})");
 
         if (indexType == PgVectorIndexType.IvfFlat)
@@ -325,19 +327,11 @@ internal static class SqlGenerator
         ArgumentException.ThrowIfNullOrWhiteSpace(linkName);
         ArgumentException.ThrowIfNullOrWhiteSpace(targetTableName);
 
-        var junctionTableName = $"{sourceTableName}_{TypeMapper.ToSnakeCase(linkName)}";
-        var qSchema = QuoteIdentifier(schema);
-
-        var sb = new StringBuilder();
-        sb.AppendLine($"CREATE TABLE IF NOT EXISTS {qSchema}.{QuoteIdentifier(junctionTableName)} (");
-        sb.AppendLine("    edge_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),");
-        sb.AppendLine($"    source_id uuid NOT NULL REFERENCES {qSchema}.{QuoteIdentifier(sourceTableName)} (id),");
-        sb.AppendLine($"    target_id uuid NOT NULL REFERENCES {qSchema}.{QuoteIdentifier(targetTableName)} (id),");
-        sb.AppendLine("    UNIQUE (source_id, target_id)");
-        sb.AppendLine(");");
-        AppendReverseJunctionIndex(sb, schema, junctionTableName);
-
-        return sb.ToString();
+        // #130 R3a: the DDL derives the junction identifier through the SAME
+        // function the relate/unrelate/traversal DML uses, so an over-long
+        // {source}_{link} name is capped identically on both sides.
+        var junctionTableName = JunctionTableName(sourceTableName, linkName);
+        return BuildJunctionTableDdlByName(schema, junctionTableName, sourceTableName, targetTableName);
     }
 
     /// <summary>
@@ -366,10 +360,48 @@ internal static class SqlGenerator
     }
 
     /// <summary>
-    /// Resolves the snake_cased junction table name for a pure link
+    /// Resolves the physical object (vertex or association-object) table
+    /// identifier for a descriptor NAME: snake_cased via
+    /// <see cref="TypeMapper.ToSnakeCase(string)"/>, then passed through
+    /// <see cref="PgIdentifier.Derive(string)"/> so it can never exceed
+    /// PostgreSQL's silent 63-byte truncation limit (#130 R3a). EVERY table-name
+    /// resolution in the provider — read path, write path, schema bootstrap,
+    /// relate endpoints, association plans — and every DDL builder routes through
+    /// this one function, so the DDL and the DML can never name different
+    /// physical tables for one descriptor. A name within the cap is returned
+    /// byte-identical to the plain snake_case lowering.
+    /// </summary>
+    /// <param name="descriptorName">The ontology descriptor name (INV-8: identity by name).</param>
+    internal static string ObjectTableName(string descriptorName)
+    {
+        ArgumentNullException.ThrowIfNull(descriptorName);
+        return PgIdentifier.Derive(TypeMapper.ToSnakeCase(descriptorName));
+    }
+
+    /// <summary>
+    /// Resolves the role-disambiguated <c>{role}_id</c> endpoint FK column
+    /// identifier for an association endpoint role, passed through
+    /// <see cref="PgIdentifier.Derive(string)"/> so an over-long role can never
+    /// be silently truncated by PostgreSQL (#130 R3a). The association DDL and
+    /// the attributed relate/unrelate DML both derive the column through this
+    /// one function.
+    /// </summary>
+    /// <param name="role">The endpoint role (e.g. <c>"Employee"</c>).</param>
+    internal static string RoleColumnName(string role)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        return PgIdentifier.Derive($"{TypeMapper.ToSnakeCase(role)}_id");
+    }
+
+    /// <summary>
+    /// Resolves the junction table identifier for a pure link
     /// <c>(source, link)</c> — the SAME identifier
-    /// <see cref="BuildJunctionTableDdl"/> creates, so relate/unrelate writes
-    /// and the schema DDL can never drift (DR-7).
+    /// <see cref="BuildJunctionTableDdl"/> creates, so relate/unrelate writes,
+    /// the traversal read and the schema DDL can never drift (DR-7). The
+    /// <c>{source}_{snake(link)}</c> name is passed through
+    /// <see cref="JunctionIdentifier.Derive(string)"/> so it can never exceed
+    /// PostgreSQL's silent 63-byte truncation limit (#130 R3a); a name within
+    /// the cap is returned verbatim.
     /// </summary>
     /// <param name="sourceTableName">
     /// The source endpoint's object table name (already snake_cased).
@@ -379,7 +411,7 @@ internal static class SqlGenerator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceTableName);
         ArgumentException.ThrowIfNullOrWhiteSpace(linkName);
-        return $"{sourceTableName}_{TypeMapper.ToSnakeCase(linkName)}";
+        return JunctionIdentifier.Derive($"{sourceTableName}_{TypeMapper.ToSnakeCase(linkName)}");
     }
 
     /// <summary>
@@ -471,9 +503,12 @@ internal static class SqlGenerator
     /// <summary>
     /// Builds one junction table's DDL from an already-derived junction name and
     /// the source/target object table names. Shared by
-    /// <see cref="BuildJunctionTableDdlForResolvedTargets"/>; emits the same edge
-    /// shape as <see cref="BuildJunctionTableDdl"/> (edge identity + two endpoint
-    /// FKs + endpoint-pair uniqueness) but with the DR-11-resolved identifier.
+    /// <see cref="BuildJunctionTableDdl"/> (the <c>(source, link)</c> name from
+    /// <see cref="JunctionTableName(string, string)"/>) and
+    /// <see cref="BuildJunctionTableDdlForResolvedTargets"/> (the DR-11-resolved
+    /// name from <see cref="JunctionTableNameFor(JunctionTableDescriptor)"/>), so
+    /// both emit one edge shape: edge identity + two endpoint FKs + endpoint-pair
+    /// uniqueness + the reverse-traversal index.
     /// </summary>
     private static string BuildJunctionTableDdlByName(
         string schema,
@@ -1039,10 +1074,12 @@ internal static class SqlGenerator
         // specified more than once". ToSnakeCase only lowercases/underscores, so
         // roles that differ only by case or separators (e.g. "Owner" / "owner")
         // collide after normalization. Surface a typed, actionable error here.
+        // The check runs on the DERIVED column (#130 R3a) so it is the identifier
+        // Postgres will actually see that is compared, never the raw name.
         var roleColumns = new HashSet<string>(StringComparer.Ordinal);
         foreach (var endpoint in association.AssociationEndpoints)
         {
-            var roleColumn = $"{TypeMapper.ToSnakeCase(endpoint.Role)}_id";
+            var roleColumn = RoleColumnName(endpoint.Role);
             if (!roleColumns.Add(roleColumn))
             {
                 throw new ArgumentException(
@@ -1054,7 +1091,11 @@ internal static class SqlGenerator
         }
 
         var qSchema = QuoteIdentifier(schema);
-        var tableName = TypeMapper.ToSnakeCase(association.Name);
+
+        // #130 R3a: the association-object table, its endpoint FK targets and its
+        // {role}_id columns all derive through the same capped resolvers the
+        // attributed relate/unrelate plan (ResolveAssociationRelate) uses.
+        var tableName = ObjectTableName(association.Name);
 
         var sb = new StringBuilder();
 
@@ -1080,8 +1121,8 @@ internal static class SqlGenerator
             // ToSnakeCase only lowercases/underscores — it does not neutralize a
             // quote or space in a role name. Quoting in BOTH positions keeps the
             // DDL column and the INSERT column the SAME physical identifier.
-            var columnName = QuoteIdentifier($"{TypeMapper.ToSnakeCase(endpoint.Role)}_id");
-            var endpointTable = TypeMapper.ToSnakeCase(endpoint.DescriptorName);
+            var columnName = QuoteIdentifier(RoleColumnName(endpoint.Role));
+            var endpointTable = ObjectTableName(endpoint.DescriptorName);
             endpointKeyColumns.Add(columnName);
             sb.AppendLine(
                 $"    {columnName} uuid NOT NULL REFERENCES {qSchema}.{QuoteIdentifier(endpointTable)} (id),");
@@ -1129,7 +1170,7 @@ internal static class SqlGenerator
         // valid-time endpoints (INCLUDE) so an as-of-now valid-time filter is an
         // index-only scan. The sequenced (both-axes) class is deliberately NOT
         // indexed (design §4.3).
-        var asOfNowIndex = QuoteIdentifier($"idx_{tableName}_as_of_now");
+        var asOfNowIndex = QuoteIdentifier(PgIdentifier.Derive($"idx_{tableName}_as_of_now"));
         sb.Append(
             $"CREATE INDEX IF NOT EXISTS {asOfNowIndex} "
             + $"ON {qSchema}.{QuoteIdentifier(tableName)} (system_from) "

--- a/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
+++ b/src/Strategos.Ontology.Npgsql/PgVectorObjectSetProvider.cs
@@ -81,7 +81,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     internal static string ResolveTableName(ObjectSetExpression expression)
     {
         ArgumentNullException.ThrowIfNull(expression);
-        return TypeMapper.ToSnakeCase(expression.RootObjectTypeName);
+        return SqlGenerator.ObjectTableName(expression.RootObjectTypeName);
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     internal static string ResolveTableNameForDescriptor(string descriptorName)
     {
         ArgumentNullException.ThrowIfNull(descriptorName);
-        return TypeMapper.ToSnakeCase(descriptorName);
+        return SqlGenerator.ObjectTableName(descriptorName);
     }
 
     /// <summary>
@@ -139,7 +139,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
             if (names.Count == 1)
             {
-                return TypeMapper.ToSnakeCase(names[0]);
+                return SqlGenerator.ObjectTableName(names[0]);
             }
 
             throw new InvalidOperationException(
@@ -155,7 +155,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         // Graph absent — fall back to typeof(T).Name → snake_case for
         // back-compat with direct unit-test instantiation and DI
         // configurations that do not resolve an OntologyGraph.
-        return TypeMapper.ToSnakeCase(typeof(T).Name);
+        return SqlGenerator.ObjectTableName(typeof(T).Name);
     }
 
     /// <inheritdoc />
@@ -728,7 +728,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         }
 
         return new RelateEndpoint(
-            TypeMapper.ToSnakeCase(descriptorName),
+            SqlGenerator.ObjectTableName(descriptorName),
             descriptor.KeyProperty.Name);
     }
 
@@ -1011,12 +1011,15 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
 
         return new AssociationRelatePlan
         {
-            AssociationTable = TypeMapper.ToSnakeCase(associationDescriptor),
+            // #130 R3a: the table and the {role}_id columns derive through the same
+            // capped resolvers BuildAssociationObjectTableDdl uses, so the DDL and
+            // this DML plan can never name different physical identifiers.
+            AssociationTable = SqlGenerator.ObjectTableName(associationDescriptor),
             AssociationKeyProperty = association.KeyProperty.Name,
-            SourceColumn = $"{TypeMapper.ToSnakeCase(sourceEndpoint.Role)}_id",
+            SourceColumn = SqlGenerator.RoleColumnName(sourceEndpoint.Role),
             SourceTable = source.TableName,
             SourceKeyProperty = source.KeyProperty,
-            TargetColumn = $"{TypeMapper.ToSnakeCase(targetEndpoint.Role)}_id",
+            TargetColumn = SqlGenerator.RoleColumnName(targetEndpoint.Role),
             TargetTable = target.TableName,
             TargetKeyProperty = target.KeyProperty,
         };
@@ -1252,7 +1255,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
         foreach (var descriptor in _graph.ObjectTypes)
         {
             ct.ThrowIfCancellationRequested();
-            var tableName = TypeMapper.ToSnakeCase(descriptor.Name);
+            var tableName = SqlGenerator.ObjectTableName(descriptor.Name);
             await EnsureSchemaForTableAsync(tableName, descriptor.KeyProperty?.Name, ct).ConfigureAwait(false);
         }
     }
@@ -1344,7 +1347,7 @@ public sealed class PgVectorObjectSetProvider : IObjectSetProvider, IObjectSetWr
     {
         if (descriptorName is not null)
         {
-            return TypeMapper.ToSnakeCase(descriptorName);
+            return SqlGenerator.ObjectTableName(descriptorName);
         }
 
         return ResolveTableNameForDefaultOverload<T>(graph);

--- a/src/Strategos.Ontology.Npgsql/Schema/JunctionIdentifier.cs
+++ b/src/Strategos.Ontology.Npgsql/Schema/JunctionIdentifier.cs
@@ -1,6 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
-
 namespace Strategos.Ontology.Npgsql.Schema;
 
 /// <summary>
@@ -9,119 +6,17 @@ namespace Strategos.Ontology.Npgsql.Schema;
 /// (<c>NAMEDATALEN - 1</c>) deterministically.
 /// </summary>
 /// <remarks>
-/// PostgreSQL truncates any identifier longer than 63 BYTES SILENTLY, so two
-/// distinct junction names that share a 63-byte prefix would collapse onto one
-/// physical table — a collision, not a server error. <see cref="Derive(string)"/>
-/// keeps short names verbatim and, for over-long names, truncates to
-/// <c>(63 - suffix)</c> bytes and appends a deterministic hash suffix computed
-/// from the FULL name. The suffix is derived from a fixed (process-independent)
-/// hash so the same input always yields the same identifier — DDL and the
-/// relate/traverse DML can never drift. The two-arg
-/// <see cref="Derive(string, string)"/> overload makes the residual hash-collision
-/// case MECHANICAL by throwing a typed
-/// <see cref="OntologySchemaIdentifierException"/>. INV-2: pure, deterministic
-/// SQL-identity logic — no live database.
+/// The junction-named facade over the general <see cref="PgIdentifier"/> guard
+/// (#130 R3a): every generated identifier — vertex, junction and
+/// association-object table, <c>{role}_id</c> endpoint column, index — derives
+/// through <see cref="PgIdentifier.Derive(string)"/>, and this type delegates to
+/// it unchanged so the junction call sites and their tests keep their name.
 /// </remarks>
 internal static class JunctionIdentifier
 {
-    /// <summary>The PostgreSQL identifier byte cap (<c>NAMEDATALEN - 1</c>).</summary>
-    private const int MaxIdentifierBytes = 63;
+    /// <inheritdoc cref="PgIdentifier.Derive(string)"/>
+    internal static string Derive(string name) => PgIdentifier.Derive(name);
 
-    /// <summary>
-    /// The deterministic hash suffix length in hex chars (ASCII, so 1 byte each).
-    /// Eight hex chars (32 bits) keeps the collision probability negligible while
-    /// leaving the bulk of the 63-byte budget for the human-readable prefix.
-    /// </summary>
-    private const int HashHexLength = 8;
-
-    /// <summary>The full suffix is <c>'_' + HashHexLength</c> ASCII bytes.</summary>
-    private const int SuffixBytes = 1 + HashHexLength;
-
-    /// <summary>
-    /// Derives a 63-byte-safe PostgreSQL identifier for <paramref name="name"/>.
-    /// A name already within the byte cap is returned VERBATIM; an over-long name
-    /// is truncated to <c>(63 - suffix)</c> UTF-8 bytes (on a char boundary) and a
-    /// deterministic <c>_{hash}</c> suffix computed from the FULL name is appended,
-    /// so two distinct over-long names sharing a prefix derive distinct
-    /// identifiers.
-    /// </summary>
-    /// <param name="name">The logical junction identifier (already snake_cased).</param>
-    internal static string Derive(string name)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
-
-        if (Encoding.UTF8.GetByteCount(name) <= MaxIdentifierBytes)
-        {
-            return name;
-        }
-
-        var suffix = "_" + DeterministicHashHex(name);
-        var prefix = TruncateToBytes(name, MaxIdentifierBytes - SuffixBytes);
-        return prefix + suffix;
-    }
-
-    /// <summary>
-    /// Derives identifiers for two DISTINCT junction names and throws
-    /// <see cref="OntologySchemaIdentifierException"/> when they collide — the
-    /// mechanical guard for the silent 63-byte-truncation collision. Two EQUAL
-    /// inputs are not a collision (they are the same table) and pass through.
-    /// </summary>
-    /// <param name="first">The first junction name.</param>
-    /// <param name="second">The second junction name.</param>
-    /// <returns>The derived identifier for <paramref name="first"/>.</returns>
-    internal static string Derive(string first, string second)
-    {
-        var derivedFirst = Derive(first);
-        var derivedSecond = Derive(second);
-
-        if (!string.Equals(first, second, StringComparison.Ordinal)
-            && string.Equals(derivedFirst, derivedSecond, StringComparison.Ordinal))
-        {
-            throw new OntologySchemaIdentifierException(first, second, derivedFirst);
-        }
-
-        return derivedFirst;
-    }
-
-    // A process-INDEPENDENT short hash of the full name. string.GetHashCode is
-    // randomized per process (and thus unusable for a stable SQL identifier), so
-    // we take the leading bytes of a SHA-256 digest and render them as lowercase
-    // hex. Determinism is the contract — the DDL and DML must derive the SAME
-    // identifier across runs.
-    private static string DeterministicHashHex(string name)
-    {
-        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(name));
-        var sb = new StringBuilder(HashHexLength);
-        for (var i = 0; sb.Length < HashHexLength; i++)
-        {
-            sb.Append(digest[i].ToString("x2"));
-        }
-
-        return sb.ToString(0, HashHexLength);
-    }
-
-    // Truncates to at most maxBytes UTF-8 bytes WITHOUT splitting a Unicode
-    // scalar (an identifier with a torn code unit would be invalid UTF-8). Walks
-    // by Rune (scalar value), accumulating each scalar's UTF-8 byte cost, and
-    // stops before the budget is exceeded. For the snake_cased ASCII identifiers
-    // this layer handles, each Rune is a single byte; the Rune walk just keeps
-    // any non-ASCII descriptor name byte-safe too.
-    private static string TruncateToBytes(string value, int maxBytes)
-    {
-        var bytes = 0;
-        var sb = new StringBuilder(value.Length);
-        foreach (var rune in value.EnumerateRunes())
-        {
-            var runeBytes = rune.Utf8SequenceLength;
-            if (bytes + runeBytes > maxBytes)
-            {
-                break;
-            }
-
-            bytes += runeBytes;
-            sb.Append(rune.ToString());
-        }
-
-        return sb.ToString();
-    }
+    /// <inheritdoc cref="PgIdentifier.Derive(string, string)"/>
+    internal static string Derive(string first, string second) => PgIdentifier.Derive(first, second);
 }

--- a/src/Strategos.Ontology.Npgsql/Schema/OntologySchemaIdentifierException.cs
+++ b/src/Strategos.Ontology.Npgsql/Schema/OntologySchemaIdentifierException.cs
@@ -41,8 +41,8 @@ public sealed class OntologySchemaIdentifierException : Exception
 
         return $"Schema identifiers '{firstName}' and '{secondName}' both derive the PostgreSQL "
             + $"identifier '{derivedIdentifier}'. PostgreSQL truncates identifiers at 63 bytes "
-            + $"silently, so these two distinct junction targets would collapse onto one physical "
-            + $"table. Rename one descriptor/link so their derived identifiers differ.";
+            + $"silently, so these two distinct schema objects would collapse onto one physical "
+            + $"table or column. Rename one descriptor/link/role so their derived identifiers differ.";
     }
 
     /// <summary>The first colliding input name.</summary>

--- a/src/Strategos.Ontology.Npgsql/Schema/PgIdentifier.cs
+++ b/src/Strategos.Ontology.Npgsql/Schema/PgIdentifier.cs
@@ -1,0 +1,129 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Strategos.Ontology.Npgsql.Schema;
+
+/// <summary>
+/// Derives a PostgreSQL-safe identifier for ANY generated schema object — a
+/// vertex (object) table, a per-<c>(link, target-descriptor)</c> junction table,
+/// a reified association-object table, a <c>{role}_id</c> endpoint column or an
+/// index — guarding the 63-byte identifier limit (<c>NAMEDATALEN - 1</c>)
+/// deterministically (#130 R3a, generalizing the DR-11/#128 junction guard).
+/// </summary>
+/// <remarks>
+/// PostgreSQL truncates any identifier longer than 63 BYTES SILENTLY, so two
+/// distinct names that share a 63-byte prefix would collapse onto one physical
+/// object — a collision, not a server error. <see cref="Derive(string)"/> keeps
+/// short names verbatim and, for over-long names, truncates to
+/// <c>(63 - suffix)</c> bytes and appends a deterministic hash suffix computed
+/// from the FULL name. The suffix is derived from a fixed (process-independent)
+/// hash so the same input always yields the same identifier — the DDL and the
+/// relate/unrelate/traverse DML derive through THIS one function and can never
+/// drift. The two-arg <see cref="Derive(string, string)"/> overload makes the
+/// residual hash-collision case MECHANICAL by throwing a typed
+/// <see cref="OntologySchemaIdentifierException"/>. INV-2: pure, deterministic
+/// SQL-identity logic — no live database.
+/// </remarks>
+internal static class PgIdentifier
+{
+    /// <summary>The PostgreSQL identifier byte cap (<c>NAMEDATALEN - 1</c>).</summary>
+    internal const int MaxIdentifierBytes = 63;
+
+    /// <summary>
+    /// The deterministic hash suffix length in hex chars (ASCII, so 1 byte each).
+    /// Eight hex chars (32 bits) keeps the collision probability negligible while
+    /// leaving the bulk of the 63-byte budget for the human-readable prefix.
+    /// </summary>
+    private const int HashHexLength = 8;
+
+    /// <summary>The full suffix is <c>'_' + HashHexLength</c> ASCII bytes.</summary>
+    private const int SuffixBytes = 1 + HashHexLength;
+
+    /// <summary>
+    /// Derives a 63-byte-safe PostgreSQL identifier for <paramref name="name"/>.
+    /// A name already within the byte cap is returned VERBATIM; an over-long name
+    /// is truncated to <c>(63 - suffix)</c> UTF-8 bytes (on a char boundary) and a
+    /// deterministic <c>_{hash}</c> suffix computed from the FULL name is appended,
+    /// so two distinct over-long names sharing a prefix derive distinct
+    /// identifiers.
+    /// </summary>
+    /// <param name="name">The logical identifier (already snake_cased).</param>
+    internal static string Derive(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (Encoding.UTF8.GetByteCount(name) <= MaxIdentifierBytes)
+        {
+            return name;
+        }
+
+        var suffix = "_" + DeterministicHashHex(name);
+        var prefix = TruncateToBytes(name, MaxIdentifierBytes - SuffixBytes);
+        return prefix + suffix;
+    }
+
+    /// <summary>
+    /// Derives identifiers for two DISTINCT logical names and throws
+    /// <see cref="OntologySchemaIdentifierException"/> when they collide — the
+    /// mechanical guard for the silent 63-byte-truncation collision. Two EQUAL
+    /// inputs are not a collision (they are the same object) and pass through.
+    /// </summary>
+    /// <param name="first">The first logical name.</param>
+    /// <param name="second">The second logical name.</param>
+    /// <returns>The derived identifier for <paramref name="first"/>.</returns>
+    internal static string Derive(string first, string second)
+    {
+        var derivedFirst = Derive(first);
+        var derivedSecond = Derive(second);
+
+        if (!string.Equals(first, second, StringComparison.Ordinal)
+            && string.Equals(derivedFirst, derivedSecond, StringComparison.Ordinal))
+        {
+            throw new OntologySchemaIdentifierException(first, second, derivedFirst);
+        }
+
+        return derivedFirst;
+    }
+
+    // A process-INDEPENDENT short hash of the full name. string.GetHashCode is
+    // randomized per process (and thus unusable for a stable SQL identifier), so
+    // we take the leading bytes of a SHA-256 digest and render them as lowercase
+    // hex. Determinism is the contract — the DDL and DML must derive the SAME
+    // identifier across runs.
+    private static string DeterministicHashHex(string name)
+    {
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(name));
+        var sb = new StringBuilder(HashHexLength);
+        for (var i = 0; sb.Length < HashHexLength; i++)
+        {
+            sb.Append(digest[i].ToString("x2"));
+        }
+
+        return sb.ToString(0, HashHexLength);
+    }
+
+    // Truncates to at most maxBytes UTF-8 bytes WITHOUT splitting a Unicode
+    // scalar (an identifier with a torn code unit would be invalid UTF-8). Walks
+    // by Rune (scalar value), accumulating each scalar's UTF-8 byte cost, and
+    // stops before the budget is exceeded. For the snake_cased ASCII identifiers
+    // this layer handles, each Rune is a single byte; the Rune walk just keeps
+    // any non-ASCII descriptor name byte-safe too.
+    private static string TruncateToBytes(string value, int maxBytes)
+    {
+        var bytes = 0;
+        var sb = new StringBuilder(value.Length);
+        foreach (var rune in value.EnumerateRunes())
+        {
+            var runeBytes = rune.Utf8SequenceLength;
+            if (bytes + runeBytes > maxBytes)
+            {
+                break;
+            }
+
+            bytes += runeBytes;
+            sb.Append(rune.ToString());
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

- Routes **every** generated Npgsql identifier — vertex, junction and association-object table names, `{role}_id` endpoint columns and index names — through one 63-byte guard (`PgIdentifier`, the generalized DR-11 `JunctionIdentifier`), so the DDL and the relate/unrelate/traversal DML always derive the same identifier. This closes the one real gap left in #130 (R3a).
- Dispositions the rest of #130: everything else already shipped, one half-item is declined with a reason, one is a deliberate split.

## Disposition of #130

| Item | Status | Evidence |
|---|---|---|
| R1 reverse junction index | Done — #136 (v2.9.0) | `SqlGenerator.AppendReverseJunctionIndex`; `Schema/JunctionIndexTests.cs` |
| R2 unique expression index on the vertex key path | Done — #136 (not #129 as the body guesses) | `SqlGenerator.BuildSchemaCreationDdl(keyPropertyName)`, threaded from `PgVectorObjectSetProvider.EnsureSchemaForTableAsync`; `Schema/VertexIndexTests.cs`. All DDL is `IF NOT EXISTS`. |
| R3a identifier-length guard | **Fixed here** | See *Changes* |
| R4 `NpgsqlBatch` relate / TOCTOU | Done | `RelateAsync` → `ExecuteValidatingRelateAsync`: one self-validating data-modifying CTE in a single `NpgsqlBatch` |
| R5 statement preparation / `NpgsqlDataSource` posture | Done, except positional `$1` parameters — **declined** | Injected `NpgsqlDataSource`, Npgsql pinned 10.0.3, `DefaultMaxAutoPrepare = 25` in `PgVectorServiceCollectionExtensions`. Positional parameters would touch every SQL builder and `ExpressionTranslator` to save a client-side rewrite that auto-prepare already amortizes. |
| R6 `RelateBatchAsync` | Deliberately split | Contract reserved on `IObjectSetWriter` and implemented in-memory; Npgsql throws `NotSupportedException` until an ingestion consumer exists (#115) — the issue itself said "defer until an ingestion consumer exists". |
| R8 pgvector iterative-scan knobs | Done | `IterativeScanOptions`, `SqlGenerator.BuildIterativeScanSimilarityQuery` |

The issue body's "this window has CLOSED … any change here is now a migration" framing is retracted: `git merge-base --is-ancestor e05dae9 v2.9.0` succeeds, i.e. #136 (`e05dae9`) is an ancestor of the `v2.9.0` tag, so the R1/R2 indexes shipped *with* the junction/association schema. No deployed schema lacks them and no migration exists or is needed. This PR is migration-free too: every identifier within 63 bytes is byte-identical to before, and a longer name never worked (relate wrote to the hashed table while the DDL and the traversal used the raw, server-truncated name → `42P01`).

## Changes

- `Schema/PgIdentifier.cs` (new, `internal`): the truncate-to-54-bytes + `_` + 8-hex SHA-256-suffix guard, moved out of `JunctionIdentifier`, which now delegates to it. No public surface change; `OntologySchemaIdentifierException`'s message is generalized from "junction targets" to "schema objects".
- `SqlGenerator`: new `ObjectTableName(descriptorName)` and `RoleColumnName(role)` resolvers; `JunctionTableName` derives; `BuildJunctionTableDdl` now shares `BuildJunctionTableDdlByName` with the DR-11 builder so the junction DDL and DML cannot drift; `BuildAssociationObjectTableDdl` derives the table, the endpoint FK targets, the `{role}_id` columns (the collision guard now compares the *derived* columns) and the as-of-now index; `BuildSchemaCreationDdl` derives the embedding index name.
- `PgVectorObjectSetProvider`: every table/column derivation routes through those resolvers — `ResolveTableName`, `ResolveTableNameForDescriptor`, `ResolveTableNameForDefaultOverload` (both branches), `ResolveRelateEndpoint`, `ResolveAssociationRelate` (table + both role columns), `EnsureAllSchemasAsync`, `ResolveEnsureSchemaTableName`.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry. `docs/src/content/docs/reference/ontology/npgsql.md`: one paragraph stating the cap and DDL/DML agreement.

## Test plan

- [x] `dotnet run --project src/Strategos.Ontology.Npgsql.Tests/Strategos.Ontology.Npgsql.Tests.csproj -- --treenode-filter "/*/*/IdentifierGuardTests/*"` — 4 new tests, each **red first** on the unfixed code (raw >63-byte names in the DDL / drift between `JunctionTableNameFor` and `ResolveTraversalHop`), green after: **7/7**.
  - long monomorphic junction: junction DDL (both builders), `ResolveRelateJunction` + `JunctionTableNameFor`, `BuildValidatingRelateInsertSql`, `BuildUnrelateDeleteSql`, `JunctionTableName`, `ResolveTraversalHop` + `BuildInstanceAnchoredTraversalSql` all name one derived table
  - long association descriptor + long endpoint: table, endpoint FK target, as-of-now index in the DDL; `ResolveAssociationRelate` plan, insert SQL and as-of SQL agree
  - long vertex descriptor: all five table-name resolvers agree; `BuildSchemaCreationDdl` caps the embedding index
  - two endpoint roles sharing a 63-byte prefix: distinct, capped columns in the DDL and in the relate plan/insert; the case-only normalization collision still throws
- [x] `dotnet run --project src/Strategos.Ontology.Npgsql.Tests/Strategos.Ontology.Npgsql.Tests.csproj` — 199 total, 184 passed, 15 skipped (DB-gated, no `STRATEGOS_PG_TEST_CONN`), 0 failed
- [x] `dotnet run --project src/Strategos.Ontology.Tests/Strategos.Ontology.Tests.csproj` — 1168 passed
- [x] `dotnet run --project src/Strategos.Identity.Abstractions.Tests/Strategos.Identity.Abstractions.Tests.csproj` — 45 passed (`ReleaseShapeTests` read the CHANGELOG)
- [x] Existing generated-SQL assertions (`RationaleOntologyParityTests`, `JunctionDdlTests`, `JunctionDmlRoutingTests`, `PgVectorEdgeSchemaTests`, `PgVectorAssociationTests`, …) unchanged and green — names within the cap are byte-identical.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
