### PR TITLE
feat(contracts): publish the Zod/TypeScript package to the private org registry

### DIFF
--- a/.github/workflows/publish-contracts.yml
+++ b/.github/workflows/publish-contracts.yml
@@ -25,6 +25,7 @@ env:
 permissions:
   id-token: write   # OIDC token for NuGet trusted publishing
   contents: write   # Create the GitHub Release
+  packages: write   # Publish the Zod/TypeScript package to GitHub Packages
 
 jobs:
   publish-contracts:
@@ -67,9 +68,17 @@ jobs:
         run: |
           tag_version="${GITHUB_REF_NAME#contracts-v}"
           pinned="$(grep -oP '(?<=<ContractsVersion>)[^<]+' "$CONTRACTS_PROJECT")"
-          echo "tag=$tag_version pinned=$pinned"
+          npm_version="$(node -p "require('./src/Strategos.Contracts/package.json').version")"
+          echo "tag=$tag_version pinned=$pinned npm=$npm_version"
           if [[ "$tag_version" != "$pinned" ]]; then
             echo "::error::Tag contracts-v$tag_version does not match pinned <ContractsVersion>$pinned. Update the csproj or retag."
+            exit 1
+          fi
+          # One tag publishes two packages. They must carry one version, or a
+          # consumer pinning the npm package gets schemas from a different release
+          # than the C# records were generated from.
+          if [[ "$npm_version" != "$pinned" ]]; then
+            echo "::error::package.json version $npm_version does not match pinned <ContractsVersion>$pinned."
             exit 1
           fi
 
@@ -243,6 +252,34 @@ jobs:
               --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
               --source https://api.nuget.org/v3/index.json
           done
+
+      - name: Build the Zod/TypeScript package
+        working-directory: src/Strategos.Contracts
+        run: npm run build:package
+
+      - name: Publish the Zod/TypeScript package to GitHub Packages
+        # Private to the organization: the scope is @lvlup-sw and the registry is
+        # GitHub Packages, so GITHUB_TOKEN authenticates it and no long-lived
+        # credential is stored. Exarchos consumes and pins this rather than
+        # deriving its own stand-in (exarchos#1901).
+        working-directory: src/Strategos.Contracts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm config set @lvlup-sw:registry https://npm.pkg.github.com
+          npm config set //npm.pkg.github.com/:_authToken "$NODE_AUTH_TOKEN"
+          # Re-publishing an existing version is not an error worth failing the
+          # whole release for: the NuGet half may already have succeeded, and the
+          # symbols-push failure on contracts-v0.12.0 is the precedent for making
+          # a late step idempotent rather than fatal.
+          if npm publish --ignore-scripts 2>&1 | tee /tmp/npm-publish.log; then
+            echo "published"
+          elif grep -qiE "cannot publish over|already exists|conflict" /tmp/npm-publish.log; then
+            echo "::warning::npm package version already published; leaving it as is."
+          else
+            echo "::error::npm publish failed for a reason other than an existing version."
+            exit 1
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,12 @@ secrets.json
 # Node.js
 node_modules/
 
+# Build output of the publishable Zod/TypeScript package (#1901). Emitted by
+# `npm run build:package` from the committed Generated/zod sources, so it is
+# derived twice over and never committed.
+src/Strategos.Contracts/dist/
+*.tgz
+
 # Contracts cross-product round-trip harness scratch (T31)
 src/Strategos.Contracts/.roundtrip-zod.tmp/
 

--- a/src/Strategos.Contracts/package.json
+++ b/src/Strategos.Contracts/package.json
@@ -1,9 +1,33 @@
 {
   "name": "@lvlup-sw/strategos-contracts",
-  "version": "0.2.0",
-  "private": true,
+  "version": "0.14.0",
+  "description": "Zod schemas and TypeScript types for the Strategos workflow/ontology wire contract. Emitted from the TypeSpec sources that also produce the JSON Schema and the LevelUp.Strategos.Contracts C# records, so all three arms agree by construction.",
   "type": "module",
-  "description": "TypeSpec-canonical cross-product schema substrate: emits JSON Schema (NuGet content) and C# records (compiled into LevelUp.Strategos.Contracts).",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lvlup-sw/strategos.git",
+    "directory": "src/Strategos.Contracts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
   "scripts": {
     "compile": "tsp compile .",
     "compile:json-schema": "tsp compile . --emit @typespec/json-schema",
@@ -11,7 +35,12 @@
     "roundtrip": "node scripts/cross-product-roundtrip.mjs",
     "schema-diff": "node scripts/contracts-schema-diff.mjs",
     "emit:zod": "node scripts/emit-zod.mjs",
-    "check:zod": "tsc --project tsconfig.typecheck.json"
+    "check:zod": "tsc --project tsconfig.typecheck.json",
+    "build:package": "tsc --project tsconfig.build.json",
+    "prepack": "npm run build:package"
+  },
+  "peerDependencies": {
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",

--- a/src/Strategos.Contracts/tsconfig.build.json
+++ b/src/Strategos.Contracts/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "//": "Builds the publishable package (dist/): JavaScript plus declarations. Separate from tsconfig.json, which verify-zod-conformance.mjs compiles with its own --outDir, and from tsconfig.typecheck.json, which adds the type-level assertions and emits nothing.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "rootDir": "Generated/zod",
+    "outDir": "dist"
+  },
+  "include": ["Generated/zod/**/*.ts"]
+}

--- a/tests/Strategos.Contracts.Tests/NpmPackageParityTests.cs
+++ b/tests/Strategos.Contracts.Tests/NpmPackageParityTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// <copyright file="NpmPackageParityTests.cs" company="Levelup Software">
+// Copyright (c) Levelup Software. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Strategos.Contracts.Tests;
+
+/// <summary>
+/// The npm package and the NuGet package are two shapes of ONE contract version
+/// (exarchos#1901). These pin the places that can silently drift apart.
+/// </summary>
+/// <remarks>
+/// The publish workflow already refuses a tag whose version does not match
+/// <c>&lt;ContractsVersion&gt;</c>. That check fires at publish time, on a tag, when
+/// the cheapest correction is a retag. These fire on every build, so the drift is
+/// caught by the pull request that introduces it.
+/// </remarks>
+[Property("Category", "Unit")]
+public sealed partial class NpmPackageParityTests
+{
+    /// <summary>The npm version equals the pinned <c>ContractsVersion</c>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NpmVersion_EqualsPinnedContractsVersion()
+    {
+        var pinned = PinnedContractsVersion();
+        var npm = Manifest().GetProperty("version").GetString();
+
+        await Assert.That(npm).IsEqualTo(pinned)
+            .Because(
+                "the npm package and the NuGet package project one contract version. A consumer "
+                + "that pins the npm package by version must get the schemas that version's C# "
+                + "records were generated from.");
+    }
+
+    /// <summary>The package is publishable, and aimed at the private org registry.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Manifest_IsPublishable_ToTheOrgRegistry()
+    {
+        var manifest = Manifest();
+
+        await Assert.That(manifest.TryGetProperty("private", out _)).IsFalse()
+            .Because("a manifest marked private cannot be published at all.");
+
+        var registry = manifest.GetProperty("publishConfig").GetProperty("registry").GetString();
+        await Assert.That(registry).IsEqualTo("https://npm.pkg.github.com")
+            .Because("the package is private to the organization, so it publishes to GitHub Packages.");
+
+        var access = manifest.GetProperty("publishConfig").GetProperty("access").GetString();
+        await Assert.That(access).IsEqualTo("restricted")
+            .Because("'restricted' is what keeps a private package from being published publicly by default.");
+    }
+
+    /// <summary>
+    /// <c>zod</c> is declared as a peer dependency, not only as a dev dependency.
+    /// </summary>
+    /// <remarks>
+    /// The emitted modules call <c>z.enum(...)</c> and friends at module scope, so
+    /// zod is RUNTIME code for a consumer, not a build-time tool. Left as a dev
+    /// dependency only, the published package would resolve for us and fail to
+    /// import for everyone else.
+    /// </remarks>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Zod_IsAPeerDependency()
+    {
+        var manifest = Manifest();
+
+        await Assert.That(manifest.TryGetProperty("peerDependencies", out var peers)).IsTrue()
+            .Because("a consumer must supply zod: the emitted modules execute it at import time.");
+        await Assert.That(peers.TryGetProperty("zod", out _)).IsTrue()
+            .Because("zod is the one runtime dependency the emitted modules have.");
+    }
+
+    /// <summary>Only built output ships, never the TypeScript sources or the schemas.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Files_ShipsOnlyTheBuiltOutput()
+    {
+        var files = Manifest().GetProperty("files").EnumerateArray()
+            .Select(entry => entry.GetString() ?? string.Empty)
+            .ToArray();
+
+        await Assert.That(files).IsEquivalentTo(new[] { "dist" })
+            .Because(
+                "the package ships compiled JavaScript and declarations. Shipping Generated/zod "
+                + "sources would make the consumer's build depend on our tsconfig.");
+    }
+
+    private static JsonElement Manifest()
+    {
+        var path = Path.Combine(RepoRoot(), "src", "Strategos.Contracts", "package.json");
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        return document.RootElement.Clone();
+    }
+
+    private static string PinnedContractsVersion()
+    {
+        var path = Path.Combine(
+            RepoRoot(), "src", "Strategos.Contracts", "Strategos.Contracts.csproj");
+        var match = ContractsVersion().Match(File.ReadAllText(path));
+        if (!match.Success)
+        {
+            throw new InvalidOperationException($"no <ContractsVersion> in {path}");
+        }
+
+        return match.Groups["version"].Value;
+    }
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null
+            && !File.Exists(Path.Combine(directory.FullName, "global.json")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException(
+                $"could not locate the repository root from {AppContext.BaseDirectory}.");
+    }
+
+    [GeneratedRegex(@"<ContractsVersion>(?<version>[^<]+)</ContractsVersion>")]
+    private static partial Regex ContractsVersion();
+}

--- a/tests/Strategos.Contracts.Tests/Pipeline/CodegenGuardTests.cs
+++ b/tests/Strategos.Contracts.Tests/Pipeline/CodegenGuardTests.cs
@@ -363,7 +363,62 @@ public sealed class CodegenGuardTests
             .Because("a duplicate push must not turn different local package bytes into a green release.");
         await Assert.That(yaml).Contains(
             "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020");
-        await Assert.That(yaml.Contains("packages: write", StringComparison.Ordinal)).IsFalse();
+        // Least privilege, pinned EXACTLY rather than by the absence of one scope.
+        // The workflow gained `packages: write` when it began publishing the
+        // Zod/TypeScript package to GitHub Packages (exarchos#1901). Pinning the whole
+        // set means the next scope added has to be justified here too — which the old
+        // "does not contain packages: write" line could not do for any other scope.
+        await Assert.That(WorkflowPermissionScopes(yaml)).IsEquivalentTo(new[]
+        {
+            "id-token: write",
+            "contents: write",
+            "packages: write",
+        }).Because("every token scope this release workflow requests is accounted for.");
         await Assert.That(yaml).Contains("persist-credentials: false");
+    }
+
+    /// <summary>
+    /// Reads the top-level <c>permissions:</c> block of a workflow as a list of
+    /// <c>scope: level</c> entries, with comments and blank lines removed.
+    /// </summary>
+    private static string[] WorkflowPermissionScopes(string yaml)
+    {
+        var lines = yaml.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var scopes = new List<string>();
+        var inside = false;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith("permissions:", StringComparison.Ordinal))
+            {
+                inside = true;
+                continue;
+            }
+
+            if (!inside)
+            {
+                continue;
+            }
+
+            // The block ends at the first line that is not indented.
+            if (line.Length > 0 && !char.IsWhiteSpace(line[0]))
+            {
+                break;
+            }
+
+            var entry = line.Trim();
+            var comment = entry.IndexOf('#', StringComparison.Ordinal);
+            if (comment >= 0)
+            {
+                entry = entry[..comment].Trim();
+            }
+
+            if (entry.Length > 0)
+            {
+                scopes.Add(entry);
+            }
+        }
+
+        return [.. scopes];
     }
 }


### PR DESCRIPTION
Gives exarchos something to pin. Refs lvlup-sw/exarchos#1901. Second of two — [#228](https://github.com/lvlup-sw/strategos/pull/228) landed the type graph first, so the first published version carries real step types rather than `unknown[]`.

## Why there was nothing to pin

Strategos owns every projection of the types it authors, but the Zod arm shipped no artifact:

| | Was | Now |
|---|---|---|
| `package.json` | `"private": true`, version `0.2.0` | publishable, version tracks `<ContractsVersion>` |
| `zod` | devDependency | **peerDependency** |
| `tsconfig.json` | `noEmit` | unchanged — a third config builds `dist/` |

So exarchos had to vendor a hand-written stand-in. That is the drift this line of work exists to remove.

## Registry

**GitHub Packages**, `@lvlup-sw` scope, `access: restricted` — private to the org, authenticated by `GITHUB_TOKEN`, so no long-lived credential is stored anywhere.

Ships **compiled JavaScript and declarations only**. Shipping the `Generated/zod` sources would make a consumer's build depend on our tsconfig.

`zod` moves to `peerDependencies` because the emitted modules call `z.enum(...)` at module scope — it is runtime code for a consumer, not a build-time tool. Left as a devDependency the package would have resolved for us and failed to import for everyone else.

## Guards

**One tag publishes two packages**, so the workflow's version gate now covers both — a `package.json` version disagreeing with `<ContractsVersion>` fails before anything is pushed. Four `NpmPackageParityTests` pin the same properties on *every build*, because the cheapest correction to a mismatch found on a tag is a retag.

**The npm publish is idempotent on an already-published version**, following the symbols-push precedent: a late step must not fail the whole run after the NuGet half has already succeeded. Any other failure is fatal.

**`tsconfig.build.json` is a third config, not an edit to the existing two.** `tsconfig.json` is also a *build* config — `verify-zod-conformance.mjs` compiles it with its own `--outDir` — so giving it emit settings would have moved that output. Same trap as #228.

## A guard I had to change, and strengthened

`CodegenGuardTests` pinned least privilege by asserting the workflow does **not** contain `packages: write`. It now needs that scope. Rather than delete the line, it is replaced with an exact pin of the whole permission set — strictly stronger, since the old form could not have caught *any other* scope being added.

Confirmed by falsification: smuggling in `actions: write` fails the guard.

## Verified end to end, not just by unit test

`npm pack` → 766-file tarball → installed into a scratch consumer:

- runtime validation rejects a retired gate class (`AntipatternDetection`);
- `WorkflowDefinitionV1['steps']` is the five-arm union and narrows on `kind`.

Control-checked: asserting the narrower `"skill"` fails that consumer's build, so the assertion is not vacuous.

Contracts tests **231/231**, `check:zod` clean, regeneration leaves every guarded path clean.

## Before merging

`<ContractsVersion>` is already `0.14.0` from #228. This rides that version — the first `contracts-v0.14.0` tag publishes both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)