### PR TITLE
docs: record the Zod package's publication channel in the 3.0.0 handoff

### DIFF
--- a/docs/handoffs/2026-09-11-3.0.0-consumer-upgrade.md
+++ b/docs/handoffs/2026-09-11-3.0.0-consumer-upgrade.md
@@ -127,10 +127,44 @@ Everything in the rc.1 notice, plus:
 - A sweep of every hand-authored `.workflow.json` for out-of-vocabulary closed-enum
   tokens, before the 3.0 build starts.
 
+## The Zod package
+
+Added 2026-09-12, after this notice was first written. At the time it said Strategos
+committed `Generated/zod/` but did not publish it, leaving exarchos nothing to pin.
+It does now.
+
+`@lvlup-sw/strategos-contracts` publishes to **GitHub Packages**, private to the
+organization, from the same `contracts-v*` tag that publishes the NuGet package. One
+tag, two packages, one version: a release gate fails if `package.json` and
+`<ContractsVersion>` disagree, so the npm version a consumer pins and the schemas the
+C# records were generated from are the same release by construction.
+
+First published version: **0.14.0**, alongside `LevelUp.Strategos.Contracts` 0.14.0.
+It is deliberately not 0.13.0 — the TypeScript type graph landed first
+(#223), so the first version anyone pins already infers
+`WorkflowDefinitionV1['steps']` as the five-arm step union rather than `unknown[]`.
+
+Consuming it needs two things:
+
+1. an `.npmrc` pointing the scope at the registry —
+   `@lvlup-sw:registry=https://npm.pkg.github.com`;
+2. a token with `read:packages`. In Actions that is `GITHUB_TOKEN`; on a developer
+   machine it is a personal access token.
+
+The package is **private**, so each consuming repository is granted read access on
+the package itself. That grant is a one-time step per repository, done in the
+package settings rather than in any repository's source.
+
+`zod` is a **peer** dependency. The emitted modules execute it at import time, so a
+consumer supplies it: `npm install @lvlup-sw/strategos-contracts zod`.
+
+lvlup-sw/exarchos#1901 carries the worked install.
+
 ## Not swept
 
 - Whether any consumer hand-authors `.workflow.json` outside its test corpus. The
   `AGWF049` exposure above is stated as a risk, not as a measured finding.
-- Whether exarchos's `contract-authority.lock.json` mechanism can pin a generated
-  artifact from another repository without a publication channel for it. Strategos
-  commits `Generated/zod/` but does not publish it as an npm package.
+- ~~Whether exarchos's `contract-authority.lock.json` mechanism can pin a generated
+  artifact from another repository without a publication channel for it.~~
+  **Resolved 2026-09-12.** There is a publication channel now: see *The Zod package*
+  below.


### PR DESCRIPTION
The 3.0.0 consumer notice was written before the package existed. Under **Not swept** it told consumers:

> Strategos commits `Generated/zod/` but does not publish it as an npm package.

That is now false. A consumer-facing document asserting it would send exarchos looking for a vendoring strategy it no longer needs.

## What this adds

A **The Zod package** section recording:

- `@lvlup-sw/strategos-contracts` publishes to GitHub Packages, private to the org, from the same `contracts-v*` tag as the NuGet package — one tag, two packages, one version, with a release gate that fails if `package.json` and `<ContractsVersion>` disagree.
- The two things consuming it needs: the scoped `.npmrc` line, and a token with `read:packages` (`GITHUB_TOKEN` in Actions).
- That the per-repository read grant is a one-time step in the **package settings**, not anything in a consumer's source — the part that isn't discoverable from any repo.
- `zod` is a peer dependency, because the emitted modules execute it at import time.
- Why the first published version is **0.14.0 and not 0.13.0**: the type graph (#223) landed first, so the first version anyone pins already infers `steps` as the five-arm union rather than `unknown[]`.

The **Not swept** entry is struck through rather than deleted, so a reader who remembers the open question can see it was answered instead of wondering whether it was quietly dropped.

`docs/handoffs/` sits outside the Starlight content collection, so this is a repo document and not part of the site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)